### PR TITLE
[codex] Fix flight setup and boarding pass mobile UI

### DIFF
--- a/app/flight/boarding-pass.tsx
+++ b/app/flight/boarding-pass.tsx
@@ -7,9 +7,9 @@
  */
 
 import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { useCallback, useEffect, useRef } from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
+import { Animated, ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { BoardingPass } from '@/components/flight/BoardingPass';
@@ -25,14 +25,13 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   content: {
-    flex: 1,
-    justifyContent: 'center',
     alignItems: 'center',
-    padding: Spacing.xl,
+    padding: Spacing.lg,
+    paddingBottom: Spacing.md,
   },
   header: {
     alignItems: 'center',
-    marginBottom: Spacing.xl,
+    marginBottom: Spacing.lg,
   },
   title: {
     fontSize: Typography.fontSize.xxl,
@@ -45,12 +44,15 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   passContainer: {
-    marginBottom: Spacing.xl,
+    width: '100%',
+    alignItems: 'center',
+    marginBottom: Spacing.lg,
   },
   instruction: {
     fontSize: Typography.fontSize.base,
     textAlign: 'center',
-    marginBottom: Spacing.xl,
+    marginBottom: Spacing.lg,
+    lineHeight: 24,
   },
   footer: {
     padding: Spacing.lg,
@@ -115,12 +117,17 @@ export default function BoardingPassScreen() {
   return (
     <ThemedView style={styles.container}>
       <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.content}>
+        <Stack.Screen options={{ headerShown: false }} />
+
+        <ScrollView
+          contentContainerStyle={styles.content}
+          showsVerticalScrollIndicator={false}
+        >
           {/* Header */}
           <View style={styles.header}>
             <ThemedText style={styles.title}>Boarding Pass</ThemedText>
             <ThemedText style={[styles.subtitle, { color: colors.success }]}>
-              ✓ Checked In
+              Checked In
             </ThemedText>
           </View>
 
@@ -141,7 +148,7 @@ export default function BoardingPassScreen() {
           <ThemedText style={[styles.instruction, { color: colors.textSecondary }]}>
             Ready to board! Tap the button below to begin your flight.
           </ThemedText>
-        </View>
+        </ScrollView>
 
         {/* Footer */}
         <View style={styles.footer}>

--- a/app/flight/boarding-pass.tsx
+++ b/app/flight/boarding-pass.tsx
@@ -24,7 +24,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  scrollView: {
+    flex: 1,
+  },
   content: {
+    flexGrow: 1,
     alignItems: 'center',
     padding: Spacing.lg,
     paddingBottom: Spacing.md,
@@ -120,6 +124,7 @@ export default function BoardingPassScreen() {
         <Stack.Screen options={{ headerShown: false }} />
 
         <ScrollView
+          style={styles.scrollView}
           contentContainerStyle={styles.content}
           showsVerticalScrollIndicator={false}
         >

--- a/components/flight/BoardingPass.tsx
+++ b/components/flight/BoardingPass.tsx
@@ -15,6 +15,9 @@ import { BoardingPassDimensions, Colors, Spacing, Typography } from '@/constants
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { BoardingPass as BoardingPassType } from '@/types/flight';
 
+const flexOne = { flex: 1 } as const;
+const alignEnd = { alignItems: 'flex-end' } as const;
+
 const styles = StyleSheet.create({
   passContainer: {
     borderRadius: BoardingPassDimensions.cornerRadius,
@@ -50,9 +53,6 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.lg,
     paddingVertical: Spacing.md,
   },
-  airportBlock: {
-    flex: 1,
-  },
   airportCode: {
     fontSize: Typography.fontSize.xxxl,
     fontWeight: Typography.fontWeight.bold,
@@ -74,9 +74,6 @@ const styles = StyleSheet.create({
   detailRow: {
     flexDirection: 'row',
     marginBottom: Spacing.md,
-  },
-  detailBlock: {
-    flex: 1,
   },
   detailLabel: {
     fontSize: Typography.fontSize.xs,
@@ -179,7 +176,7 @@ interface DetailPairProps {
 
 function DetailPair({ colors, label, scaledStyles, value }: DetailPairProps) {
   return (
-    <View style={styles.detailBlock}>
+    <View style={flexOne}>
       <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: colors.textSecondary }]}>
         {label}
       </ThemedText>
@@ -236,7 +233,7 @@ function RouteSection({
 }: RouteSectionProps) {
   return (
     <View style={[styles.routeSection, scaledStyles.routeSpacing]}>
-      <View style={styles.airportBlock}>
+      <View style={flexOne}>
         <ThemedText style={[styles.airportCode, scaledStyles.airportCode, { color: colors.text }]}>
           {originCode}
         </ThemedText>
@@ -249,7 +246,7 @@ function RouteSection({
           →
         </ThemedText>
       </View>
-      <View style={[styles.airportBlock, { alignItems: 'flex-end' }]}>
+      <View style={[flexOne, alignEnd]}>
         <ThemedText style={[styles.airportCode, scaledStyles.airportCode, { color: colors.text }]}>
           {destinationCode}
         </ThemedText>

--- a/components/flight/BoardingPass.tsx
+++ b/components/flight/BoardingPass.tsx
@@ -125,6 +125,9 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginTop: Spacing.xs,
   },
+  passengerSection: {
+    marginBottom: Spacing.lg,
+  },
   passengerName: {
     fontSize: Typography.fontSize.lg,
     fontWeight: Typography.fontWeight.bold,
@@ -134,12 +137,217 @@ const styles = StyleSheet.create({
 });
 
 interface BoardingPassProps {
-  /** Boarding pass data */
   boardingPass: BoardingPassType;
-  /** Whether the pass can be interacted with */
   interactive?: boolean;
-  /** Callback when pass is tapped (for scan interaction) */
   onTap?: () => void;
+}
+
+interface PassColors {
+  background: string;
+  text: string;
+  textSecondary: string;
+  border: string;
+}
+
+interface ScaledStyles {
+  airline: { fontSize: number };
+  flightNumber: { fontSize: number };
+  airportCode: { fontSize: number };
+  airportName: { fontSize: number };
+  arrowText: { fontSize: number };
+  detailLabel: { fontSize: number };
+  detailValue: { fontSize: number };
+  passengerSection: { marginBottom: number };
+  passengerName: { fontSize: number; letterSpacing: number };
+  qrPlaceholder: { width: number; height: number };
+  qrText: { fontSize: number; lineHeight: number };
+  serialNumber: { fontSize: number };
+  qrNote: { fontSize: number };
+  passPadding: { padding: number };
+  headerSpacing: { paddingBottom: number; marginBottom: number };
+  routeSpacing: { marginBottom: number; paddingVertical: number };
+  detailRow: { marginBottom: number };
+  stubSection: { left: number; right: number };
+}
+
+interface DetailPairProps {
+  colors: PassColors;
+  label: string;
+  scaledStyles: ScaledStyles;
+  value: string;
+}
+
+function DetailPair({ colors, label, scaledStyles, value }: DetailPairProps) {
+  return (
+    <View style={styles.detailBlock}>
+      <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: colors.textSecondary }]}>
+        {label}
+      </ThemedText>
+      <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: colors.text }]}>
+        {value}
+      </ThemedText>
+    </View>
+  );
+}
+
+interface BoardingPassHeaderProps {
+  colors: PassColors;
+  flightNumber: string;
+  scaledStyles: ScaledStyles;
+}
+
+function BoardingPassHeader({ colors, flightNumber, scaledStyles }: BoardingPassHeaderProps) {
+  return (
+    <View
+      style={[
+        styles.header,
+        scaledStyles.headerSpacing,
+        { borderBottomColor: colors.border },
+      ]}
+    >
+      <ThemedText style={[styles.airline, scaledStyles.airline, { color: colors.text }]}>
+        TravelBlock Airlines
+      </ThemedText>
+      <ThemedText
+        style={[styles.flightNumber, scaledStyles.flightNumber, { color: colors.textSecondary }]}
+      >
+        {flightNumber}
+      </ThemedText>
+    </View>
+  );
+}
+
+interface RouteSectionProps {
+  colors: PassColors;
+  destinationCity: string;
+  destinationCode: string;
+  originCity: string;
+  originCode: string;
+  scaledStyles: ScaledStyles;
+}
+
+function RouteSection({
+  colors,
+  destinationCity,
+  destinationCode,
+  originCity,
+  originCode,
+  scaledStyles,
+}: RouteSectionProps) {
+  return (
+    <View style={[styles.routeSection, scaledStyles.routeSpacing]}>
+      <View style={styles.airportBlock}>
+        <ThemedText style={[styles.airportCode, scaledStyles.airportCode, { color: colors.text }]}>
+          {originCode}
+        </ThemedText>
+        <ThemedText style={[styles.airportName, scaledStyles.airportName, { color: colors.textSecondary }]}>
+          {originCity}
+        </ThemedText>
+      </View>
+      <View style={styles.arrow}>
+        <ThemedText style={[styles.arrowText, scaledStyles.arrowText, { color: colors.textSecondary }]}>
+          →
+        </ThemedText>
+      </View>
+      <View style={[styles.airportBlock, { alignItems: 'flex-end' }]}>
+        <ThemedText style={[styles.airportCode, scaledStyles.airportCode, { color: colors.text }]}>
+          {destinationCode}
+        </ThemedText>
+        <ThemedText style={[styles.airportName, scaledStyles.airportName, { color: colors.textSecondary }]}>
+          {destinationCity}
+        </ThemedText>
+      </View>
+    </View>
+  );
+}
+
+interface PassengerSectionProps {
+  colors: PassColors;
+  passengerName: string;
+  scaledStyles: ScaledStyles;
+}
+
+function PassengerSection({ colors, passengerName, scaledStyles }: PassengerSectionProps) {
+  return (
+    <View style={[styles.passengerSection, scaledStyles.passengerSection]}>
+      <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: colors.textSecondary }]}>
+        Passenger
+      </ThemedText>
+      <ThemedText style={[styles.passengerName, scaledStyles.passengerName, { color: colors.text }]}>
+        {passengerName}
+      </ThemedText>
+    </View>
+  );
+}
+
+interface DetailsGridProps {
+  boardingTime: string;
+  colors: PassColors;
+  departureTime: string;
+  gate: string;
+  scaledStyles: ScaledStyles;
+  seatLabel: string;
+}
+
+function DetailsGrid({
+  boardingTime,
+  colors,
+  departureTime,
+  gate,
+  scaledStyles,
+  seatLabel,
+}: DetailsGridProps) {
+  return (
+    <View style={styles.detailsGrid}>
+      <View style={[styles.detailRow, scaledStyles.detailRow]}>
+        <DetailPair colors={colors} label="Boarding" scaledStyles={scaledStyles} value={boardingTime} />
+        <DetailPair colors={colors} label="Departure" scaledStyles={scaledStyles} value={departureTime} />
+      </View>
+      <View style={[styles.detailRow, scaledStyles.detailRow]}>
+        <DetailPair colors={colors} label="Gate" scaledStyles={scaledStyles} value={gate} />
+        <DetailPair colors={colors} label="Seat" scaledStyles={scaledStyles} value={seatLabel} />
+      </View>
+    </View>
+  );
+}
+
+interface StubSectionProps {
+  bookingReference: string;
+  colors: PassColors;
+  scaledStyles: ScaledStyles;
+  serialNumber: string;
+  stubTop: number;
+}
+
+function StubSection({
+  bookingReference,
+  colors,
+  scaledStyles,
+  serialNumber,
+  stubTop,
+}: StubSectionProps) {
+  return (
+    <View
+      style={[
+        styles.stubSection,
+        scaledStyles.stubSection,
+        { position: 'absolute', top: stubTop },
+      ]}
+    >
+      <View style={[styles.qrPlaceholder, scaledStyles.qrPlaceholder]}>
+        <ThemedText style={[styles.qrText, scaledStyles.qrText, { color: '#000000' }]}>
+          BOARDING CODE{'\n'}
+          {bookingReference}
+        </ThemedText>
+      </View>
+      <ThemedText style={[styles.qrNote, scaledStyles.qrNote, { color: colors.textSecondary }]}>
+        QR rendering is not wired up yet in this build.
+      </ThemedText>
+      <ThemedText style={[styles.serialNumber, scaledStyles.serialNumber, { color: colors.textSecondary }]}>
+        {serialNumber}
+      </ThemedText>
+    </View>
+  );
 }
 
 export function BoardingPass({
@@ -150,24 +358,23 @@ export function BoardingPass({
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
   const { width: screenWidth } = useWindowDimensions();
-
-  // Pass uses dedicated boarding color scheme
-  const passColors = {
-    background: '#1E3A8A', // Deep blue
+  const passColors: PassColors = {
+    background: '#1E3A8A',
     text: '#FFFFFF',
-    textSecondary: '#93C5FD', // Light blue
-    border: '#3B82F6', // Medium blue
+    textSecondary: '#93C5FD',
+    border: '#3B82F6',
   };
 
   const { booking, seat, passengerName, serialNumber } = boardingPass;
   const originCode = booking.origin.iata || booking.origin.icao;
-  const destCode = booking.destination.iata || booking.destination.icao;
+  const destinationCode = booking.destination.iata || booking.destination.icao;
   const cardWidth = Math.min(screenWidth - Spacing.xl * 2, BoardingPassDimensions.width);
   const scale = cardWidth / BoardingPassDimensions.width;
   const cardHeight = BoardingPassDimensions.height * scale;
   const perforationTop = BoardingPassDimensions.perforationY * scale;
   const stubTop = perforationTop + 16 * scale;
-  const scaledStyles = useMemo(
+  const seatLabel = `${seat.row}${seat.letter}`;
+  const scaledStyles = useMemo<ScaledStyles>(
     () => ({
       airline: { fontSize: Typography.fontSize.xl * scale },
       flightNumber: { fontSize: Typography.fontSize.base * scale },
@@ -176,6 +383,7 @@ export function BoardingPass({
       arrowText: { fontSize: Typography.fontSize.xl * scale },
       detailLabel: { fontSize: Math.max(10, Typography.fontSize.xs * scale) },
       detailValue: { fontSize: Typography.fontSize.lg * scale },
+      passengerSection: { marginBottom: Spacing.lg * scale },
       passengerName: {
         fontSize: Typography.fontSize.lg * scale,
         letterSpacing: Math.max(1, 2 * scale),
@@ -199,7 +407,6 @@ export function BoardingPass({
     [scale]
   );
 
-  // Format times (simple formatting for now)
   const boardingTime = new Date(booking.boardingTime).toLocaleTimeString('en-US', {
     hour: '2-digit',
     minute: '2-digit',
@@ -211,7 +418,7 @@ export function BoardingPass({
 
   const handleTap = () => {
     if (!interactive || !onTap) return;
-    impactAsync(ImpactFeedbackStyle.Heavy).catch(() => {});
+    impactAsync(ImpactFeedbackStyle.Heavy).catch(() => undefined);
     onTap();
   };
 
@@ -230,106 +437,32 @@ export function BoardingPass({
       activeOpacity={interactive ? 0.8 : 1}
     >
       <View style={[styles.passContent, scaledStyles.passPadding]}>
-        {/* Header */}
-        <View
-          style={[
-            styles.header,
-            scaledStyles.headerSpacing,
-            { borderBottomColor: passColors.border },
-          ]}
-        >
-          <ThemedText style={[styles.airline, scaledStyles.airline, { color: passColors.text }]}>
-            TravelBlock Airlines
-          </ThemedText>
-          <ThemedText
-            style={[styles.flightNumber, scaledStyles.flightNumber, { color: passColors.textSecondary }]}
-          >
-            {booking.flightNumber}
-          </ThemedText>
-        </View>
-
-        {/* Route */}
-        <View style={[styles.routeSection, scaledStyles.routeSpacing]}>
-          <View style={styles.airportBlock}>
-            <ThemedText style={[styles.airportCode, scaledStyles.airportCode, { color: passColors.text }]}>
-              {originCode}
-            </ThemedText>
-            <ThemedText style={[styles.airportName, scaledStyles.airportName, { color: passColors.textSecondary }]}>
-              {booking.origin.city}
-            </ThemedText>
-          </View>
-
-          <View style={styles.arrow}>
-            <ThemedText style={[styles.arrowText, scaledStyles.arrowText, { color: passColors.textSecondary }]}>
-              →
-            </ThemedText>
-          </View>
-
-          <View style={[styles.airportBlock, { alignItems: 'flex-end' }]}>
-            <ThemedText style={[styles.airportCode, scaledStyles.airportCode, { color: passColors.text }]}>
-              {destCode}
-            </ThemedText>
-            <ThemedText style={[styles.airportName, scaledStyles.airportName, { color: passColors.textSecondary }]}>
-              {booking.destination.city}
-            </ThemedText>
-          </View>
-        </View>
-
-        {/* Passenger name */}
-        <View style={{ marginBottom: Spacing.lg * scale }}>
-          <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
-            Passenger
-          </ThemedText>
-          <ThemedText style={[styles.passengerName, scaledStyles.passengerName, { color: passColors.text }]}>
-            {passengerName}
-          </ThemedText>
-        </View>
-
-        {/* Flight details grid */}
-        <View style={styles.detailsGrid}>
-          {/* Row 1 */}
-          <View style={[styles.detailRow, scaledStyles.detailRow]}>
-            <View style={styles.detailBlock}>
-              <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
-                Boarding
-              </ThemedText>
-              <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: passColors.text }]}>
-                {boardingTime}
-              </ThemedText>
-            </View>
-            <View style={styles.detailBlock}>
-              <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
-                Departure
-              </ThemedText>
-              <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: passColors.text }]}>
-                {departureTime}
-              </ThemedText>
-            </View>
-          </View>
-
-          {/* Row 2 */}
-          <View style={[styles.detailRow, scaledStyles.detailRow]}>
-            <View style={styles.detailBlock}>
-              <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
-                Gate
-              </ThemedText>
-              <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: passColors.text }]}>
-                {booking.gate}
-              </ThemedText>
-            </View>
-            <View style={styles.detailBlock}>
-              <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
-                Seat
-              </ThemedText>
-              <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: passColors.text }]}>
-                {seat.row}
-                {seat.letter}
-              </ThemedText>
-            </View>
-          </View>
-        </View>
-
-        {/* Perforation line */}
+        <BoardingPassHeader
+          colors={passColors}
+          flightNumber={booking.flightNumber}
+          scaledStyles={scaledStyles}
+        />
+        <RouteSection
+          colors={passColors}
+          destinationCity={booking.destination.city}
+          destinationCode={destinationCode}
+          originCity={booking.origin.city}
+          originCode={originCode}
+          scaledStyles={scaledStyles}
+        />
+        <PassengerSection
+          colors={passColors}
+          passengerName={passengerName}
+          scaledStyles={scaledStyles}
+        />
+        <DetailsGrid
+          boardingTime={boardingTime}
+          colors={passColors}
+          departureTime={departureTime}
+          gate={booking.gate}
+          scaledStyles={scaledStyles}
+          seatLabel={seatLabel}
+        />
         <View
           style={[
             styles.perforationLine,
@@ -339,30 +472,13 @@ export function BoardingPass({
             },
           ]}
         />
-
-        {/* Stub section (below perforation) */}
-        <View
-          style={[
-            styles.stubSection,
-            scaledStyles.stubSection,
-            { position: 'absolute', top: stubTop },
-          ]}
-        >
-          <View style={[styles.qrPlaceholder, scaledStyles.qrPlaceholder]}>
-            <ThemedText style={[styles.qrText, scaledStyles.qrText, { color: '#000000' }]}>
-              BOARDING CODE{'\n'}
-              {booking.bookingReference}
-            </ThemedText>
-          </View>
-          <ThemedText style={[styles.qrNote, scaledStyles.qrNote, { color: passColors.textSecondary }]}>
-            QR rendering is not wired up yet in this build.
-          </ThemedText>
-
-          {/* Booking reference */}
-          <ThemedText style={[styles.serialNumber, scaledStyles.serialNumber, { color: passColors.textSecondary }]}>
-            {serialNumber}
-          </ThemedText>
-        </View>
+        <StubSection
+          bookingReference={booking.bookingReference}
+          colors={passColors}
+          scaledStyles={scaledStyles}
+          serialNumber={serialNumber}
+          stubTop={stubTop}
+        />
       </View>
     </TouchableOpacity>
   );

--- a/components/flight/BoardingPass.tsx
+++ b/components/flight/BoardingPass.tsx
@@ -164,7 +164,9 @@ interface ScaledStyles {
   headerSpacing: { paddingBottom: number; marginBottom: number };
   routeSpacing: { marginBottom: number; paddingVertical: number };
   detailRow: { marginBottom: number };
-  stubSection: { left: number; right: number };
+  stubSection: { left: number; right: number; paddingTop: number };
+  qrPlaceholderSpacing: { marginBottom: number };
+  qrNoteSpacing: { marginTop: number };
 }
 
 interface DetailPairProps {
@@ -331,13 +333,15 @@ function StubSection({
         { position: 'absolute', top: stubTop },
       ]}
     >
-      <View style={[styles.qrPlaceholder, scaledStyles.qrPlaceholder]}>
+      <View style={[styles.qrPlaceholder, scaledStyles.qrPlaceholder, scaledStyles.qrPlaceholderSpacing]}>
         <ThemedText style={[styles.qrText, scaledStyles.qrText, { color: '#000000' }]}>
           BOARDING CODE{'\n'}
           {bookingReference}
         </ThemedText>
       </View>
-      <ThemedText style={[styles.qrNote, scaledStyles.qrNote, { color: colors.textSecondary }]}>
+      <ThemedText
+        style={[styles.qrNote, scaledStyles.qrNote, scaledStyles.qrNoteSpacing, { color: colors.textSecondary }]}
+      >
         QR rendering is not wired up yet in this build.
       </ThemedText>
       <ThemedText style={[styles.serialNumber, scaledStyles.serialNumber, { color: colors.textSecondary }]}>
@@ -365,7 +369,8 @@ export function BoardingPass({
   const { booking, seat, passengerName, serialNumber } = boardingPass;
   const originCode = booking.origin.iata || booking.origin.icao;
   const destinationCode = booking.destination.iata || booking.destination.icao;
-  const cardWidth = Math.min(screenWidth - Spacing.xl * 2, BoardingPassDimensions.width);
+  const availableWidth = Math.max(240, screenWidth - Spacing.xl * 2);
+  const cardWidth = Math.min(availableWidth, BoardingPassDimensions.width);
   const scale = cardWidth / BoardingPassDimensions.width;
   const cardHeight = BoardingPassDimensions.height * scale;
   const perforationTop = BoardingPassDimensions.perforationY * scale;
@@ -399,7 +404,13 @@ export function BoardingPass({
       headerSpacing: { paddingBottom: Spacing.md * scale, marginBottom: Spacing.md * scale },
       routeSpacing: { marginBottom: Spacing.lg * scale, paddingVertical: Spacing.md * scale },
       detailRow: { marginBottom: Spacing.md * scale },
-      stubSection: { left: Spacing.lg * scale, right: Spacing.lg * scale },
+      stubSection: {
+        left: Spacing.lg * scale,
+        right: Spacing.lg * scale,
+        paddingTop: Spacing.lg * scale,
+      },
+      qrPlaceholderSpacing: { marginBottom: Spacing.md * scale },
+      qrNoteSpacing: { marginTop: Spacing.xs * scale },
     }),
     [scale]
   );

--- a/components/flight/BoardingPass.tsx
+++ b/components/flight/BoardingPass.tsx
@@ -7,7 +7,8 @@
  */
 
 import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { useMemo } from 'react';
+import { StyleSheet, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 
 import { ThemedText } from '@/components/themed-text';
 import { BoardingPassDimensions, Colors, Spacing, Typography } from '@/constants/theme';
@@ -16,8 +17,6 @@ import { BoardingPass as BoardingPassType } from '@/types/flight';
 
 const styles = StyleSheet.create({
   passContainer: {
-    width: BoardingPassDimensions.width,
-    height: BoardingPassDimensions.height,
     borderRadius: BoardingPassDimensions.cornerRadius,
     overflow: 'hidden',
     elevation: 8,
@@ -101,8 +100,8 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.lg,
   },
   qrPlaceholder: {
-    width: 120,
-    height: 120,
+    width: 128,
+    height: 128,
     backgroundColor: '#FFFFFF',
     borderRadius: 8,
     alignSelf: 'center',
@@ -113,11 +112,18 @@ const styles = StyleSheet.create({
   qrText: {
     fontSize: Typography.fontSize.xs,
     textAlign: 'center',
+    lineHeight: 18,
+    paddingHorizontal: Spacing.sm,
   },
   serialNumber: {
     fontSize: Typography.fontSize.xs,
     fontFamily: 'monospace',
     textAlign: 'center',
+  },
+  qrNote: {
+    fontSize: Typography.fontSize.xs,
+    textAlign: 'center',
+    marginTop: Spacing.xs,
   },
   passengerName: {
     fontSize: Typography.fontSize.lg,
@@ -143,6 +149,7 @@ export function BoardingPass({
 }: BoardingPassProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const { width: screenWidth } = useWindowDimensions();
 
   // Pass uses dedicated boarding color scheme
   const passColors = {
@@ -155,6 +162,42 @@ export function BoardingPass({
   const { booking, seat, passengerName, serialNumber } = boardingPass;
   const originCode = booking.origin.iata || booking.origin.icao;
   const destCode = booking.destination.iata || booking.destination.icao;
+  const cardWidth = Math.min(screenWidth - Spacing.xl * 2, BoardingPassDimensions.width);
+  const scale = cardWidth / BoardingPassDimensions.width;
+  const cardHeight = BoardingPassDimensions.height * scale;
+  const perforationTop = BoardingPassDimensions.perforationY * scale;
+  const stubTop = perforationTop + 16 * scale;
+  const scaledStyles = useMemo(
+    () => ({
+      airline: { fontSize: Typography.fontSize.xl * scale },
+      flightNumber: { fontSize: Typography.fontSize.base * scale },
+      airportCode: { fontSize: Typography.fontSize.xxxl * scale },
+      airportName: { fontSize: Math.max(11, Typography.fontSize.xs * scale) },
+      arrowText: { fontSize: Typography.fontSize.xl * scale },
+      detailLabel: { fontSize: Math.max(10, Typography.fontSize.xs * scale) },
+      detailValue: { fontSize: Typography.fontSize.lg * scale },
+      passengerName: {
+        fontSize: Typography.fontSize.lg * scale,
+        letterSpacing: Math.max(1, 2 * scale),
+      },
+      qrPlaceholder: {
+        width: 128 * scale,
+        height: 128 * scale,
+      },
+      qrText: {
+        fontSize: Math.max(10, Typography.fontSize.xs * scale),
+        lineHeight: Math.max(14, 18 * scale),
+      },
+      serialNumber: { fontSize: Math.max(10, Typography.fontSize.xs * scale) },
+      qrNote: { fontSize: Math.max(10, Typography.fontSize.xs * scale) },
+      passPadding: { padding: Spacing.lg * scale },
+      headerSpacing: { paddingBottom: Spacing.md * scale, marginBottom: Spacing.md * scale },
+      routeSpacing: { marginBottom: Spacing.lg * scale, paddingVertical: Spacing.md * scale },
+      detailRow: { marginBottom: Spacing.md * scale },
+      stubSection: { left: Spacing.lg * scale, right: Spacing.lg * scale },
+    }),
+    [scale]
+  );
 
   // Format times (simple formatting for now)
   const boardingTime = new Date(booking.boardingTime).toLocaleTimeString('en-US', {
@@ -174,55 +217,70 @@ export function BoardingPass({
 
   return (
     <TouchableOpacity
-      style={[styles.passContainer, { backgroundColor: passColors.background }]}
+      style={[
+        styles.passContainer,
+        {
+          backgroundColor: passColors.background,
+          width: cardWidth,
+          height: cardHeight,
+        },
+      ]}
       onPress={handleTap}
       disabled={!interactive}
       activeOpacity={interactive ? 0.8 : 1}
     >
-      <View style={styles.passContent}>
+      <View style={[styles.passContent, scaledStyles.passPadding]}>
         {/* Header */}
-        <View style={[styles.header, { borderBottomColor: passColors.border }]}>
-          <ThemedText style={[styles.airline, { color: passColors.text }]}>
+        <View
+          style={[
+            styles.header,
+            scaledStyles.headerSpacing,
+            { borderBottomColor: passColors.border },
+          ]}
+        >
+          <ThemedText style={[styles.airline, scaledStyles.airline, { color: passColors.text }]}>
             TravelBlock Airlines
           </ThemedText>
-          <ThemedText style={[styles.flightNumber, { color: passColors.textSecondary }]}>
+          <ThemedText
+            style={[styles.flightNumber, scaledStyles.flightNumber, { color: passColors.textSecondary }]}
+          >
             {booking.flightNumber}
           </ThemedText>
         </View>
 
         {/* Route */}
-        <View style={styles.routeSection}>
+        <View style={[styles.routeSection, scaledStyles.routeSpacing]}>
           <View style={styles.airportBlock}>
-            <ThemedText style={[styles.airportCode, { color: passColors.text }]}>
+            <ThemedText style={[styles.airportCode, scaledStyles.airportCode, { color: passColors.text }]}>
               {originCode}
             </ThemedText>
-            <ThemedText style={[styles.airportName, { color: passColors.textSecondary }]}>
+            <ThemedText style={[styles.airportName, scaledStyles.airportName, { color: passColors.textSecondary }]}>
               {booking.origin.city}
             </ThemedText>
           </View>
 
           <View style={styles.arrow}>
-            <ThemedText style={[styles.arrowText, { color: passColors.textSecondary }]}>
+            <ThemedText style={[styles.arrowText, scaledStyles.arrowText, { color: passColors.textSecondary }]}>
               →
             </ThemedText>
           </View>
 
           <View style={[styles.airportBlock, { alignItems: 'flex-end' }]}>
-            <ThemedText style={[styles.airportCode, { color: passColors.text }]}>
+            <ThemedText style={[styles.airportCode, scaledStyles.airportCode, { color: passColors.text }]}>
               {destCode}
             </ThemedText>
-            <ThemedText style={[styles.airportName, { color: passColors.textSecondary }]}>
+            <ThemedText style={[styles.airportName, scaledStyles.airportName, { color: passColors.textSecondary }]}>
               {booking.destination.city}
             </ThemedText>
           </View>
         </View>
 
         {/* Passenger name */}
-        <View style={{ marginBottom: Spacing.lg }}>
-          <ThemedText style={[styles.detailLabel, { color: passColors.textSecondary }]}>
+        <View style={{ marginBottom: Spacing.lg * scale }}>
+          <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
             Passenger
           </ThemedText>
-          <ThemedText style={[styles.passengerName, { color: passColors.text }]}>
+          <ThemedText style={[styles.passengerName, scaledStyles.passengerName, { color: passColors.text }]}>
             {passengerName}
           </ThemedText>
         </View>
@@ -230,40 +288,40 @@ export function BoardingPass({
         {/* Flight details grid */}
         <View style={styles.detailsGrid}>
           {/* Row 1 */}
-          <View style={styles.detailRow}>
+          <View style={[styles.detailRow, scaledStyles.detailRow]}>
             <View style={styles.detailBlock}>
-              <ThemedText style={[styles.detailLabel, { color: passColors.textSecondary }]}>
+              <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
                 Boarding
               </ThemedText>
-              <ThemedText style={[styles.detailValue, { color: passColors.text }]}>
+              <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: passColors.text }]}>
                 {boardingTime}
               </ThemedText>
             </View>
             <View style={styles.detailBlock}>
-              <ThemedText style={[styles.detailLabel, { color: passColors.textSecondary }]}>
+              <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
                 Departure
               </ThemedText>
-              <ThemedText style={[styles.detailValue, { color: passColors.text }]}>
+              <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: passColors.text }]}>
                 {departureTime}
               </ThemedText>
             </View>
           </View>
 
           {/* Row 2 */}
-          <View style={styles.detailRow}>
+          <View style={[styles.detailRow, scaledStyles.detailRow]}>
             <View style={styles.detailBlock}>
-              <ThemedText style={[styles.detailLabel, { color: passColors.textSecondary }]}>
+              <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
                 Gate
               </ThemedText>
-              <ThemedText style={[styles.detailValue, { color: passColors.text }]}>
+              <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: passColors.text }]}>
                 {booking.gate}
               </ThemedText>
             </View>
             <View style={styles.detailBlock}>
-              <ThemedText style={[styles.detailLabel, { color: passColors.textSecondary }]}>
+              <ThemedText style={[styles.detailLabel, scaledStyles.detailLabel, { color: passColors.textSecondary }]}>
                 Seat
               </ThemedText>
-              <ThemedText style={[styles.detailValue, { color: passColors.text }]}>
+              <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: passColors.text }]}>
                 {seat.row}
                 {seat.letter}
               </ThemedText>
@@ -276,25 +334,33 @@ export function BoardingPass({
           style={[
             styles.perforationLine,
             {
-              top: BoardingPassDimensions.perforationY,
+              top: perforationTop,
               borderColor: passColors.border,
             },
           ]}
         />
 
         {/* Stub section (below perforation) */}
-        <View style={[styles.stubSection, { position: 'absolute', top: BoardingPassDimensions.perforationY + 16, left: Spacing.lg, right: Spacing.lg }]}>
-          {/* QR Code placeholder */}
-          <View style={styles.qrPlaceholder}>
-            <ThemedText style={[styles.qrText, { color: '#000' }]}>
-              QR CODE{'\n'}
-              {serialNumber}
+        <View
+          style={[
+            styles.stubSection,
+            scaledStyles.stubSection,
+            { position: 'absolute', top: stubTop },
+          ]}
+        >
+          <View style={[styles.qrPlaceholder, scaledStyles.qrPlaceholder]}>
+            <ThemedText style={[styles.qrText, scaledStyles.qrText, { color: '#000000' }]}>
+              BOARDING CODE{'\n'}
+              {booking.bookingReference}
             </ThemedText>
           </View>
+          <ThemedText style={[styles.qrNote, scaledStyles.qrNote, { color: passColors.textSecondary }]}>
+            QR rendering is not wired up yet in this build.
+          </ThemedText>
 
           {/* Booking reference */}
-          <ThemedText style={[styles.serialNumber, { color: passColors.textSecondary }]}>
-            {booking.bookingReference}
+          <ThemedText style={[styles.serialNumber, scaledStyles.serialNumber, { color: passColors.textSecondary }]}>
+            {serialNumber}
           </ThemedText>
         </View>
       </View>

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -1,31 +1,15 @@
-/**
- * TimeSlider component provides a custom slider for selecting flight duration.
- *
- * Uses react-native-gesture-handler for smooth gesture handling and
- * react-native-reanimated for high-performance animations.
- *
- * @module components/time-slider/TimeSlider
- */
-
 import { Colors, Spacing } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
-import {
-    getDefaultTimeRange,
-    getTimeInRange,
-    snapToInterval,
-} from "@/utils/timeSlider";
+import { getDefaultTimeRange, getTimeInRange, snapToInterval } from "@/utils/timeSlider";
 import { impactAsync, ImpactFeedbackStyle } from "expo-haptics";
 import { useCallback, useEffect } from "react";
 import { LayoutChangeEvent, StyleSheet, View } from "react-native";
-import {
-    Gesture,
-    GestureDetector,
-} from "react-native-gesture-handler";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
-    runOnJS,
-    useAnimatedStyle,
-    useSharedValue,
-    withSpring,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
 } from "react-native-reanimated";
 
 interface TimeSliderProps {
@@ -98,25 +82,6 @@ const styles = StyleSheet.create({
   },
 });
 
-/**
- * A custom slider component for selecting flight duration with haptic feedback.
- *
- * Features:
- * - Smooth gesture handling with spring animations
- * - Automatic snapping to 10-minute intervals
- * - Haptic feedback on interaction
- * - Responsive to touch with hit slop for easier interaction
- *
- * @example
- * ```tsx
- * const [flightTime, setFlightTime] = useState(3600); // 1 hour
- *
- * <TimeSlider
- *   value={flightTime}
- *   onValueChange={setFlightTime}
- * />
- * ```
- */
 export function TimeSlider({
   value,
   onValueChange,
@@ -167,7 +132,6 @@ export function TimeSlider({
     });
   }, []);
 
-  // Update position when value changes externally
   useEffect(() => {
     if (!isGestureActive.value) {
       lastEmittedValue.value = value;
@@ -178,7 +142,6 @@ export function TimeSlider({
     }
   }, [isGestureActive, lastEmittedValue, translateX, value]);
 
-  // Handle track layout
   const handleTrackLayout = useCallback(
     (event: LayoutChangeEvent) => {
       const { width } = event.nativeEvent.layout;
@@ -246,12 +209,10 @@ export function TimeSlider({
 
   const sliderGesture = Gesture.Simultaneous(panGesture, tapGesture);
 
-  // Animated thumb style
   const thumbStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: translateX.value }],
   }));
 
-  // Animated active track style
   const activeTrackStyle = useAnimatedStyle(() => ({
     width: translateX.value,
   }));

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -2,7 +2,7 @@ import { Colors, Spacing } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { getDefaultTimeRange, getTimeInRange, snapToInterval } from "@/utils/timeSlider";
 import { impactAsync, ImpactFeedbackStyle } from "expo-haptics";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { LayoutChangeEvent, StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
@@ -178,6 +178,9 @@ function createSliderGestures(
       range,
       clampPosition(shared.trackWidth, event.x)
     );
+    if (nextValue === shared.lastEmittedValue.value) {
+      return;
+    }
 
     shared.isGestureActive.value = false;
     shared.lastEmittedValue.value = nextValue;
@@ -205,39 +208,48 @@ export function TimeSlider({
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? "light"];
   const defaultRange = getDefaultTimeRange();
-  const range = {
+  const range = useMemo(
+    () => ({
     minValue: min ?? defaultRange.min,
     maxValue: max ?? defaultRange.max,
     snapValue: interval ?? defaultRange.interval,
-  };
-  const shared = useSliderSharedState(value);
+    }),
+    [defaultRange.interval, defaultRange.max, defaultRange.min, interval, max, min]
+  );
+  const {
+    gestureStartX,
+    isGestureActive,
+    lastEmittedValue,
+    trackWidth,
+    translateX,
+  } = useSliderSharedState(value);
 
   const triggerHaptic = useCallback(() => {
     impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
   }, []);
 
   useEffect(() => {
-    if (!shared.isGestureActive.value) {
-      shared.lastEmittedValue.value = value;
-      shared.translateX.value = withSpring(
-        valueToPosition(shared.trackWidth, range, value),
+    if (!isGestureActive.value) {
+      lastEmittedValue.value = value;
+      translateX.value = withSpring(
+        valueToPosition(trackWidth, range, value),
         SPRING_CONFIG
       );
     }
-  }, [range, shared, value]);
+  }, [isGestureActive, lastEmittedValue, range, trackWidth, translateX, value]);
 
   const handleTrackLayout = useCallback(
     (event: LayoutChangeEvent) => {
       const { width } = event.nativeEvent.layout;
-      shared.trackWidth.value = width;
-      shared.translateX.value = valueToPosition(shared.trackWidth, range, value);
+      trackWidth.value = width;
+      translateX.value = valueToPosition(trackWidth, range, value);
     },
-    [range, shared, value]
+    [range, trackWidth, translateX, value]
   );
 
   const sliderGesture = createSliderGestures(
     range,
-    shared,
+    { gestureStartX, isGestureActive, lastEmittedValue, trackWidth, translateX },
     onGestureStart,
     onGestureEnd,
     onValueChange,
@@ -245,11 +257,11 @@ export function TimeSlider({
   );
 
   const thumbStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: shared.translateX.value }],
+    transform: [{ translateX: translateX.value }],
   }));
 
   const activeTrackStyle = useAnimatedStyle(() => ({
-    width: shared.translateX.value,
+    width: translateX.value,
   }));
 
   return (

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -7,6 +7,7 @@ import { LayoutChangeEvent, StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
   runOnJS,
+  SharedValue,
   useAnimatedStyle,
   useSharedValue,
   withSpring,
@@ -32,6 +33,7 @@ interface TimeSliderProps {
 const TRACK_HEIGHT = 8;
 const THUMB_SIZE = 32;
 const HIT_SLOP = { top: 20, bottom: 20, left: 10, right: 10 };
+const SPRING_CONFIG = { damping: 20, stiffness: 200 };
 
 const styles = StyleSheet.create({
   container: {
@@ -82,6 +84,115 @@ const styles = StyleSheet.create({
   },
 });
 
+interface SliderRange {
+  minValue: number;
+  maxValue: number;
+  snapValue: number;
+}
+
+interface SliderSharedState {
+  gestureStartX: SharedValue<number>;
+  isGestureActive: SharedValue<boolean>;
+  lastEmittedValue: SharedValue<number>;
+  trackWidth: SharedValue<number>;
+  translateX: SharedValue<number>;
+}
+
+function useSliderSharedState(value: number): SliderSharedState {
+  return {
+    trackWidth: useSharedValue(0),
+    translateX: useSharedValue(0),
+    gestureStartX: useSharedValue(0),
+    isGestureActive: useSharedValue(false),
+    lastEmittedValue: useSharedValue(value),
+  };
+}
+
+function clampPosition(trackWidth: SharedValue<number>, position: number) {
+  "worklet";
+  return Math.max(0, Math.min(trackWidth.value, position));
+}
+
+function valueToPosition(trackWidth: SharedValue<number>, range: SliderRange, value: number) {
+  "worklet";
+  if (trackWidth.value === 0) return 0;
+  const normalizedValue = (value - range.minValue) / (range.maxValue - range.minValue);
+  return normalizedValue * trackWidth.value;
+}
+
+function positionToValue(trackWidth: SharedValue<number>, range: SliderRange, position: number) {
+  "worklet";
+  if (trackWidth.value === 0) return range.minValue;
+  const normalizedPosition = position / trackWidth.value;
+  const rawValue = normalizedPosition * (range.maxValue - range.minValue) + range.minValue;
+  const constrained = getTimeInRange(rawValue, range.minValue, range.maxValue);
+  return snapToInterval(constrained, range.snapValue);
+}
+
+function createSliderGestures(
+  range: SliderRange,
+  shared: SliderSharedState,
+  onGestureStart: (() => void) | undefined,
+  onGestureEnd: (() => void) | undefined,
+  onValueChange: (value: number) => void,
+  triggerHaptic: () => void
+) {
+  const panGesture = Gesture.Pan()
+    .onBegin(() => {
+      shared.isGestureActive.value = true;
+      shared.gestureStartX.value = shared.translateX.value;
+      if (onGestureStart) {
+        runOnJS(onGestureStart)();
+      }
+      runOnJS(triggerHaptic)();
+    })
+    .onUpdate((event) => {
+      const nextPosition = clampPosition(shared.trackWidth, shared.gestureStartX.value + event.translationX);
+      shared.translateX.value = nextPosition;
+
+      const nextValue = positionToValue(shared.trackWidth, range, nextPosition);
+      if (nextValue !== shared.lastEmittedValue.value) {
+        shared.lastEmittedValue.value = nextValue;
+        runOnJS(onValueChange)(nextValue);
+        runOnJS(triggerHaptic)();
+      }
+    })
+    .onEnd(() => {
+      const finalValue = positionToValue(shared.trackWidth, range, shared.translateX.value);
+      shared.lastEmittedValue.value = finalValue;
+      shared.translateX.value = withSpring(
+        valueToPosition(shared.trackWidth, range, finalValue),
+        SPRING_CONFIG
+      );
+      shared.isGestureActive.value = false;
+
+      if (onGestureEnd) {
+        runOnJS(onGestureEnd)();
+      }
+    })
+    .hitSlop(HIT_SLOP);
+
+  const tapGesture = Gesture.Tap().onEnd((event) => {
+    const nextValue = positionToValue(
+      shared.trackWidth,
+      range,
+      clampPosition(shared.trackWidth, event.x)
+    );
+
+    shared.isGestureActive.value = false;
+    shared.lastEmittedValue.value = nextValue;
+    shared.translateX.value = withSpring(
+      valueToPosition(shared.trackWidth, range, nextValue),
+      SPRING_CONFIG
+    );
+
+    runOnJS(onValueChange)(nextValue);
+    runOnJS(triggerHaptic)();
+  });
+
+  return Gesture.Simultaneous(panGesture, tapGesture);
+}
+
 export function TimeSlider({
   value,
   onValueChange,
@@ -93,128 +204,52 @@ export function TimeSlider({
 }: TimeSliderProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? "light"];
-
   const defaultRange = getDefaultTimeRange();
-  const minValue = min ?? defaultRange.min;
-  const maxValue = max ?? defaultRange.max;
-  const snapValue = interval ?? defaultRange.interval;
-
-  const trackWidth = useSharedValue(0);
-  const translateX = useSharedValue(0);
-  const gestureStartX = useSharedValue(0);
-  const isGestureActive = useSharedValue(false);
-  const lastEmittedValue = useSharedValue(value);
-
-  const clampPosition = (position: number) => {
-    "worklet";
-    return Math.max(0, Math.min(trackWidth.value, position));
+  const range = {
+    minValue: min ?? defaultRange.min,
+    maxValue: max ?? defaultRange.max,
+    snapValue: interval ?? defaultRange.interval,
   };
-
-  const valueToPosition = (val: number) => {
-    "worklet";
-    if (trackWidth.value === 0) return 0;
-    const normalizedValue = (val - minValue) / (maxValue - minValue);
-    return normalizedValue * trackWidth.value;
-  };
-
-  const positionToValue = (position: number) => {
-    "worklet";
-    if (trackWidth.value === 0) return minValue;
-    const normalizedPosition = position / trackWidth.value;
-    const rawValue = normalizedPosition * (maxValue - minValue) + minValue;
-    const constrained = getTimeInRange(rawValue, minValue, maxValue);
-    return snapToInterval(constrained, snapValue);
-  };
+  const shared = useSliderSharedState(value);
 
   const triggerHaptic = useCallback(() => {
-    impactAsync(ImpactFeedbackStyle.Light).catch(() => {
-      // Ignore haptic errors
-    });
+    impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
   }, []);
 
   useEffect(() => {
-    if (!isGestureActive.value) {
-      lastEmittedValue.value = value;
-      translateX.value = withSpring(valueToPosition(value), {
-        damping: 20,
-        stiffness: 200,
-      });
+    if (!shared.isGestureActive.value) {
+      shared.lastEmittedValue.value = value;
+      shared.translateX.value = withSpring(
+        valueToPosition(shared.trackWidth, range, value),
+        SPRING_CONFIG
+      );
     }
-  }, [isGestureActive, lastEmittedValue, translateX, value]);
+  }, [range, shared, value]);
 
   const handleTrackLayout = useCallback(
     (event: LayoutChangeEvent) => {
       const { width } = event.nativeEvent.layout;
-      trackWidth.value = width;
-      translateX.value = valueToPosition(value);
+      shared.trackWidth.value = width;
+      shared.translateX.value = valueToPosition(shared.trackWidth, range, value);
     },
-    [trackWidth, translateX, value]
+    [range, shared, value]
   );
 
-  const panGesture = Gesture.Pan()
-    .onBegin(() => {
-      isGestureActive.value = true;
-      gestureStartX.value = translateX.value;
-      if (onGestureStart) {
-        runOnJS(onGestureStart)();
-      }
-      runOnJS(triggerHaptic)();
-    })
-    .onUpdate((event) => {
-      const newPosition = gestureStartX.value + event.translationX;
-      const constrainedPosition = clampPosition(newPosition);
-      translateX.value = constrainedPosition;
-
-      const newValue = positionToValue(constrainedPosition);
-      if (newValue !== lastEmittedValue.value) {
-        lastEmittedValue.value = newValue;
-        runOnJS(onValueChange)(newValue);
-        runOnJS(triggerHaptic)();
-      }
-    })
-    .onEnd(() => {
-      const finalValue = positionToValue(translateX.value);
-      const finalPosition = valueToPosition(finalValue);
-      lastEmittedValue.value = finalValue;
-
-      translateX.value = withSpring(finalPosition, {
-        damping: 20,
-        stiffness: 200,
-      });
-
-      isGestureActive.value = false;
-
-      if (onGestureEnd) {
-        runOnJS(onGestureEnd)();
-      }
-    })
-    .hitSlop(HIT_SLOP);
-
-  const tapGesture = Gesture.Tap()
-    .onEnd((event) => {
-      const tappedPosition = clampPosition(event.x);
-      const nextValue = positionToValue(tappedPosition);
-      const finalPosition = valueToPosition(nextValue);
-
-      isGestureActive.value = false;
-      lastEmittedValue.value = nextValue;
-      translateX.value = withSpring(finalPosition, {
-        damping: 20,
-        stiffness: 200,
-      });
-
-      runOnJS(onValueChange)(nextValue);
-      runOnJS(triggerHaptic)();
-    });
-
-  const sliderGesture = Gesture.Simultaneous(panGesture, tapGesture);
+  const sliderGesture = createSliderGestures(
+    range,
+    shared,
+    onGestureStart,
+    onGestureEnd,
+    onValueChange,
+    triggerHaptic
+  );
 
   const thumbStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
+    transform: [{ translateX: shared.translateX.value }],
   }));
 
   const activeTrackStyle = useAnimatedStyle(() => ({
-    width: translateX.value,
+    width: shared.translateX.value,
   }));
 
   return (

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -15,12 +15,11 @@ import {
     snapToInterval,
 } from "@/utils/timeSlider";
 import { impactAsync, ImpactFeedbackStyle } from "expo-haptics";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 import { LayoutChangeEvent, StyleSheet, View } from "react-native";
 import {
     Gesture,
     GestureDetector,
-    GestureHandlerRootView,
 } from "react-native-gesture-handler";
 import Animated, {
     runOnJS,
@@ -55,6 +54,11 @@ const styles = StyleSheet.create({
     width: "100%",
     paddingHorizontal: Spacing.md,
     paddingVertical: Spacing.lg,
+    position: "relative",
+  },
+  sliderSurface: {
+    height: THUMB_SIZE,
+    justifyContent: "center",
   },
   trackContainer: {
     height: TRACK_HEIGHT,
@@ -132,32 +136,31 @@ export function TimeSlider({
 
   const trackWidth = useSharedValue(0);
   const translateX = useSharedValue(0);
+  const gestureStartX = useSharedValue(0);
   const isGestureActive = useSharedValue(false);
-  const lastHapticValue = useRef(value);
+  const lastEmittedValue = useSharedValue(value);
 
-  // Calculate position from value
-  const valueToPosition = useCallback(
-    (val: number) => {
-      if (trackWidth.value === 0) return 0;
-      const normalizedValue = (val - minValue) / (maxValue - minValue);
-      return normalizedValue * trackWidth.value;
-    },
-    [minValue, maxValue, trackWidth]
-  );
+  const clampPosition = (position: number) => {
+    "worklet";
+    return Math.max(0, Math.min(trackWidth.value, position));
+  };
 
-  // Calculate value from position
-  const positionToValue = useCallback(
-    (position: number) => {
-      if (trackWidth.value === 0) return minValue;
-      const normalizedPosition = position / trackWidth.value;
-      const rawValue = normalizedPosition * (maxValue - minValue) + minValue;
-      const constrained = getTimeInRange(rawValue, minValue, maxValue);
-      return snapToInterval(constrained, snapValue);
-    },
-    [minValue, maxValue, snapValue, trackWidth]
-  );
+  const valueToPosition = (val: number) => {
+    "worklet";
+    if (trackWidth.value === 0) return 0;
+    const normalizedValue = (val - minValue) / (maxValue - minValue);
+    return normalizedValue * trackWidth.value;
+  };
 
-  // Trigger haptic feedback
+  const positionToValue = (position: number) => {
+    "worklet";
+    if (trackWidth.value === 0) return minValue;
+    const normalizedPosition = position / trackWidth.value;
+    const rawValue = normalizedPosition * (maxValue - minValue) + minValue;
+    const constrained = getTimeInRange(rawValue, minValue, maxValue);
+    return snapToInterval(constrained, snapValue);
+  };
+
   const triggerHaptic = useCallback(() => {
     impactAsync(ImpactFeedbackStyle.Light).catch(() => {
       // Ignore haptic errors
@@ -167,12 +170,13 @@ export function TimeSlider({
   // Update position when value changes externally
   useEffect(() => {
     if (!isGestureActive.value) {
+      lastEmittedValue.value = value;
       translateX.value = withSpring(valueToPosition(value), {
         damping: 20,
         stiffness: 200,
       });
     }
-  }, [value, valueToPosition, isGestureActive, translateX]);
+  }, [isGestureActive, lastEmittedValue, translateX, value]);
 
   // Handle track layout
   const handleTrackLayout = useCallback(
@@ -181,29 +185,26 @@ export function TimeSlider({
       trackWidth.value = width;
       translateX.value = valueToPosition(value);
     },
-    [trackWidth, translateX, valueToPosition, value]
+    [trackWidth, translateX, value]
   );
 
-  // Gesture handler using new Gesture API
   const panGesture = Gesture.Pan()
     .onBegin(() => {
       isGestureActive.value = true;
+      gestureStartX.value = translateX.value;
       if (onGestureStart) {
         runOnJS(onGestureStart)();
       }
       runOnJS(triggerHaptic)();
     })
     .onUpdate((event) => {
-      const startX = valueToPosition(value);
-      const newPosition = startX + event.translationX;
-      const constrainedPosition = Math.max(
-        0,
-        Math.min(trackWidth.value, newPosition)
-      );
+      const newPosition = gestureStartX.value + event.translationX;
+      const constrainedPosition = clampPosition(newPosition);
       translateX.value = constrainedPosition;
 
       const newValue = positionToValue(constrainedPosition);
-      if (newValue !== value) {
+      if (newValue !== lastEmittedValue.value) {
+        lastEmittedValue.value = newValue;
         runOnJS(onValueChange)(newValue);
         runOnJS(triggerHaptic)();
       }
@@ -211,6 +212,7 @@ export function TimeSlider({
     .onEnd(() => {
       const finalValue = positionToValue(translateX.value);
       const finalPosition = valueToPosition(finalValue);
+      lastEmittedValue.value = finalValue;
 
       translateX.value = withSpring(finalPosition, {
         damping: 20,
@@ -225,6 +227,25 @@ export function TimeSlider({
     })
     .hitSlop(HIT_SLOP);
 
+  const tapGesture = Gesture.Tap()
+    .onEnd((event) => {
+      const tappedPosition = clampPosition(event.x);
+      const nextValue = positionToValue(tappedPosition);
+      const finalPosition = valueToPosition(nextValue);
+
+      isGestureActive.value = false;
+      lastEmittedValue.value = nextValue;
+      translateX.value = withSpring(finalPosition, {
+        damping: 20,
+        stiffness: 200,
+      });
+
+      runOnJS(onValueChange)(nextValue);
+      runOnJS(triggerHaptic)();
+    });
+
+  const sliderGesture = Gesture.Simultaneous(panGesture, tapGesture);
+
   // Animated thumb style
   const thumbStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: translateX.value }],
@@ -236,26 +257,28 @@ export function TimeSlider({
   }));
 
   return (
-    <GestureHandlerRootView style={styles.container}>
-      <View
-        style={[styles.trackContainer, { backgroundColor: colors.border }]}
-        onLayout={handleTrackLayout}
-      >
-        <View style={[styles.track, { backgroundColor: colors.border }]} />
-        <Animated.View
-          style={[
-            styles.activeTrack,
-            { backgroundColor: colors.tint },
-            activeTrackStyle,
-          ]}
-        />
-      </View>
+    <View style={styles.container}>
+      <GestureDetector gesture={sliderGesture}>
+        <View style={styles.sliderSurface}>
+          <View
+            style={[styles.trackContainer, { backgroundColor: colors.border }]}
+            onLayout={handleTrackLayout}
+          >
+            <View style={[styles.track, { backgroundColor: colors.border }]} />
+            <Animated.View
+              style={[
+                styles.activeTrack,
+                { backgroundColor: colors.tint },
+                activeTrackStyle,
+              ]}
+            />
+          </View>
 
-      <GestureDetector gesture={panGesture}>
-        <Animated.View style={[styles.thumbContainer, thumbStyle]}>
-          <View style={[styles.thumb, { borderColor: colors.tint }]} />
-        </Animated.View>
+          <Animated.View style={[styles.thumbContainer, thumbStyle]}>
+            <View style={[styles.thumb, { borderColor: colors.tint }]} />
+          </Animated.View>
+        </View>
       </GestureDetector>
-    </GestureHandlerRootView>
+    </View>
   );
 }

--- a/screens/FlightSetupScreen.tsx
+++ b/screens/FlightSetupScreen.tsx
@@ -244,7 +244,7 @@ export default function FlightSetupScreen() {
   } = useDestinations({
     origin: homeAirport,
     flightTimeInSeconds: localFlightTime,
-    useTimeRange: true,
+    useTimeRange: false,
   });
 
   // Find the selected destination in the destinations array


### PR DESCRIPTION
## Summary

This PR fixes two issues found during on-device testing in the flight setup and boarding pass flow.

The flight duration slider looked interactive but was not behaving reliably on a real device. Dragging the thumb at the left edge could crash the app, and the screen often showed no available destinations at the default one-hour duration. That made the setup flow feel broken before the user could even reach booking.

The boarding pass screen also exposed two polish problems on smaller phones. Expo Router was showing the raw route title in a top header even though the screen is already using a custom layout, and the boarding pass card used a fixed-size composition that caused the pass and supporting text to crowd each other. The screen also implied a QR code existed when the current build only renders a placeholder block.

## Root Cause

The slider was still using fragile gesture math and layout assumptions that did not hold up at the track edges. Destination filtering was also using a narrower time-window mode, which made the default one-hour setting return an empty list too often.

The boarding pass layout was built around a fixed card size and a centered page layout, so smaller screens had no room to breathe. The route header was simply not being disabled for that screen. The QR area was a visual placeholder rather than a real QR renderer, which made it look broken instead of intentionally incomplete.

## Fix

The slider now uses safer gesture-driven position math, keeps interaction state in shared values, and supports tapping the track directly. The flight setup screen now queries reachable destinations within the selected duration, so the default setup shows realistic nearby options.

The boarding pass route now hides the Expo Router header and uses a scrollable layout instead of a rigid centered block. The pass component scales to available device width, adjusts its typography and spacing responsively, and presents the code area as an explicit boarding-code fallback until a real QR renderer is added.

## Validation

I verified the changes with:

- `npx tsc --noEmit`
- `npm test -- --runInBand`
