### PR TITLE
[codex] Fix flight setup slider native width animation

### DIFF
--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -162,7 +162,7 @@ export function TimeSlider({
         ...SPRING_CONFIG,
       }).start();
     },
-    [position, range.maxValue, range.minValue]
+    [position, range]
   );
 
   const emitValue = useCallback(
@@ -217,7 +217,10 @@ export function TimeSlider({
         onMoveShouldSetPanResponder: () => true,
         onPanResponderGrant: () => {
           isDraggingRef.current = true;
-          gestureStartRef.current = currentPositionRef.current;
+          position.stopAnimation((animatedPosition) => {
+            currentPositionRef.current = animatedPosition;
+            gestureStartRef.current = animatedPosition;
+          });
           onGestureStart?.();
           triggerHaptic();
         },
@@ -261,9 +264,8 @@ export function TimeSlider({
       onGestureEnd,
       onGestureStart,
       onValueChange,
-      range.maxValue,
-      range.minValue,
-      range.snapValue,
+      position,
+      range,
       setPosition,
       triggerHaptic,
     ]

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -2,45 +2,35 @@ import { Colors, Spacing } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { getDefaultTimeRange, getTimeInRange, snapToInterval } from "@/utils/timeSlider";
 import { impactAsync, ImpactFeedbackStyle } from "expo-haptics";
-import { useCallback, useEffect, useMemo } from "react";
-import { LayoutChangeEvent, StyleSheet, View } from "react-native";
-import { Gesture, GestureDetector } from "react-native-gesture-handler";
-import Animated, {
-  runOnJS,
-  SharedValue,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-} from "react-native-reanimated";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  Animated,
+  LayoutChangeEvent,
+  PanResponder,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
 
 interface TimeSliderProps {
-  /** Current time value in seconds */
   value: number;
-  /** Callback when value changes */
   onValueChange: (value: number) => void;
-  /** Callback when gesture starts */
   onGestureStart?: () => void;
-  /** Callback when gesture ends */
   onGestureEnd?: () => void;
-  /** Minimum time in seconds (default: 30min) */
   min?: number;
-  /** Maximum time in seconds (default: 5h) */
   max?: number;
-  /** Snap interval in seconds (default: 10min) */
   interval?: number;
 }
 
 const TRACK_HEIGHT = 8;
 const THUMB_SIZE = 32;
-const HIT_SLOP = { top: 20, bottom: 20, left: 10, right: 10 };
-const SPRING_CONFIG = { damping: 20, stiffness: 200 };
+const SPRING_CONFIG = { damping: 20, stiffness: 200, useNativeDriver: false };
 
 const styles = StyleSheet.create({
   container: {
     width: "100%",
     paddingHorizontal: Spacing.md,
     paddingVertical: Spacing.lg,
-    position: "relative",
   },
   sliderSurface: {
     height: THUMB_SIZE,
@@ -50,7 +40,6 @@ const styles = StyleSheet.create({
     height: TRACK_HEIGHT,
     borderRadius: TRACK_HEIGHT / 2,
     overflow: "hidden",
-    position: "relative",
   },
   track: {
     flex: 1,
@@ -84,116 +73,28 @@ const styles = StyleSheet.create({
   },
 });
 
-interface SliderRange {
-  minValue: number;
-  maxValue: number;
-  snapValue: number;
+function clampPosition(trackWidth: number, position: number) {
+  return Math.max(0, Math.min(trackWidth, position));
 }
 
-interface SliderSharedState {
-  gestureStartX: SharedValue<number>;
-  isGestureActive: SharedValue<boolean>;
-  lastEmittedValue: SharedValue<number>;
-  trackWidth: SharedValue<number>;
-  translateX: SharedValue<number>;
+function valueToPosition(trackWidth: number, minValue: number, maxValue: number, value: number) {
+  if (trackWidth === 0) return 0;
+  const normalizedValue = (value - minValue) / (maxValue - minValue);
+  return normalizedValue * trackWidth;
 }
 
-function useSliderSharedState(value: number): SliderSharedState {
-  return {
-    trackWidth: useSharedValue(0),
-    translateX: useSharedValue(0),
-    gestureStartX: useSharedValue(0),
-    isGestureActive: useSharedValue(false),
-    lastEmittedValue: useSharedValue(value),
-  };
-}
-
-function clampPosition(trackWidth: SharedValue<number>, position: number) {
-  "worklet";
-  return Math.max(0, Math.min(trackWidth.value, position));
-}
-
-function valueToPosition(trackWidth: SharedValue<number>, range: SliderRange, value: number) {
-  "worklet";
-  if (trackWidth.value === 0) return 0;
-  const normalizedValue = (value - range.minValue) / (range.maxValue - range.minValue);
-  return normalizedValue * trackWidth.value;
-}
-
-function positionToValue(trackWidth: SharedValue<number>, range: SliderRange, position: number) {
-  "worklet";
-  if (trackWidth.value === 0) return range.minValue;
-  const normalizedPosition = position / trackWidth.value;
-  const rawValue = normalizedPosition * (range.maxValue - range.minValue) + range.minValue;
-  const constrained = getTimeInRange(rawValue, range.minValue, range.maxValue);
-  return snapToInterval(constrained, range.snapValue);
-}
-
-function createSliderGestures(
-  range: SliderRange,
-  shared: SliderSharedState,
-  onGestureStart: (() => void) | undefined,
-  onGestureEnd: (() => void) | undefined,
-  onValueChange: (value: number) => void,
-  triggerHaptic: () => void
+function positionToValue(
+  trackWidth: number,
+  minValue: number,
+  maxValue: number,
+  snapValue: number,
+  position: number
 ) {
-  const panGesture = Gesture.Pan()
-    .onBegin(() => {
-      shared.isGestureActive.value = true;
-      shared.gestureStartX.value = shared.translateX.value;
-      if (onGestureStart) {
-        runOnJS(onGestureStart)();
-      }
-      runOnJS(triggerHaptic)();
-    })
-    .onUpdate((event) => {
-      const nextPosition = clampPosition(shared.trackWidth, shared.gestureStartX.value + event.translationX);
-      shared.translateX.value = nextPosition;
-
-      const nextValue = positionToValue(shared.trackWidth, range, nextPosition);
-      if (nextValue !== shared.lastEmittedValue.value) {
-        shared.lastEmittedValue.value = nextValue;
-        runOnJS(onValueChange)(nextValue);
-        runOnJS(triggerHaptic)();
-      }
-    })
-    .onEnd(() => {
-      const finalValue = positionToValue(shared.trackWidth, range, shared.translateX.value);
-      shared.lastEmittedValue.value = finalValue;
-      shared.translateX.value = withSpring(
-        valueToPosition(shared.trackWidth, range, finalValue),
-        SPRING_CONFIG
-      );
-      shared.isGestureActive.value = false;
-
-      if (onGestureEnd) {
-        runOnJS(onGestureEnd)();
-      }
-    })
-    .hitSlop(HIT_SLOP);
-
-  const tapGesture = Gesture.Tap().onEnd((event) => {
-    const nextValue = positionToValue(
-      shared.trackWidth,
-      range,
-      clampPosition(shared.trackWidth, event.x)
-    );
-    if (nextValue === shared.lastEmittedValue.value) {
-      return;
-    }
-
-    shared.isGestureActive.value = false;
-    shared.lastEmittedValue.value = nextValue;
-    shared.translateX.value = withSpring(
-      valueToPosition(shared.trackWidth, range, nextValue),
-      SPRING_CONFIG
-    );
-
-    runOnJS(onValueChange)(nextValue);
-    runOnJS(triggerHaptic)();
-  });
-
-  return Gesture.Simultaneous(panGesture, tapGesture);
+  if (trackWidth === 0) return minValue;
+  const normalizedPosition = position / trackWidth;
+  const rawValue = normalizedPosition * (maxValue - minValue) + minValue;
+  const constrained = getTimeInRange(rawValue, minValue, maxValue);
+  return snapToInterval(constrained, snapValue);
 }
 
 export function TimeSlider({
@@ -210,83 +111,183 @@ export function TimeSlider({
   const defaultRange = getDefaultTimeRange();
   const range = useMemo(
     () => ({
-    minValue: min ?? defaultRange.min,
-    maxValue: max ?? defaultRange.max,
-    snapValue: interval ?? defaultRange.interval,
+      minValue: min ?? defaultRange.min,
+      maxValue: max ?? defaultRange.max,
+      snapValue: interval ?? defaultRange.interval,
     }),
     [defaultRange.interval, defaultRange.max, defaultRange.min, interval, max, min]
   );
-  const {
-    gestureStartX,
-    isGestureActive,
-    lastEmittedValue,
-    trackWidth,
-    translateX,
-  } = useSliderSharedState(value);
+
+  const position = useRef(new Animated.Value(0)).current;
+  const trackWidthRef = useRef(0);
+  const currentPositionRef = useRef(0);
+  const gestureStartRef = useRef(0);
+  const isDraggingRef = useRef(false);
+  const lastEmittedValueRef = useRef(value);
 
   const triggerHaptic = useCallback(() => {
     impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
   }, []);
 
-  useEffect(() => {
-    if (!isGestureActive.value) {
-      lastEmittedValue.value = value;
-      translateX.value = withSpring(
-        valueToPosition(trackWidth, range, value),
-        SPRING_CONFIG
+  const setPosition = useCallback(
+    (nextPosition: number) => {
+      currentPositionRef.current = nextPosition;
+      position.setValue(nextPosition);
+    },
+    [position]
+  );
+
+  const animateToValue = useCallback(
+    (nextValue: number) => {
+      const nextPosition = valueToPosition(
+        trackWidthRef.current,
+        range.minValue,
+        range.maxValue,
+        nextValue
       );
+      currentPositionRef.current = nextPosition;
+      Animated.spring(position, {
+        toValue: nextPosition,
+        ...SPRING_CONFIG,
+      }).start();
+    },
+    [position, range.maxValue, range.minValue]
+  );
+
+  const emitValue = useCallback(
+    (nextValue: number, withHaptic: boolean) => {
+      if (nextValue === lastEmittedValueRef.current) {
+        return;
+      }
+
+      lastEmittedValueRef.current = nextValue;
+      animateToValue(nextValue);
+      onValueChange(nextValue);
+      if (withHaptic) {
+        triggerHaptic();
+      }
+    },
+    [animateToValue, onValueChange, triggerHaptic]
+  );
+
+  useEffect(() => {
+    if (isDraggingRef.current) {
+      return;
     }
-  }, [isGestureActive, lastEmittedValue, range, trackWidth, translateX, value]);
+
+    lastEmittedValueRef.current = value;
+    animateToValue(value);
+  }, [animateToValue, value]);
 
   const handleTrackLayout = useCallback(
     (event: LayoutChangeEvent) => {
-      const { width } = event.nativeEvent.layout;
-      trackWidth.value = width;
-      translateX.value = valueToPosition(trackWidth, range, value);
+      trackWidthRef.current = event.nativeEvent.layout.width;
+      animateToValue(lastEmittedValueRef.current);
     },
-    [range, trackWidth, translateX, value]
+    [animateToValue]
   );
 
-  const sliderGesture = createSliderGestures(
-    range,
-    { gestureStartX, isGestureActive, lastEmittedValue, trackWidth, translateX },
-    onGestureStart,
-    onGestureEnd,
-    onValueChange,
-    triggerHaptic
+  const handleTrackPress = useCallback(
+    (locationX: number) => {
+      const nextValue = positionToValue(
+        trackWidthRef.current,
+        range.minValue,
+        range.maxValue,
+        range.snapValue,
+        clampPosition(trackWidthRef.current, locationX)
+      );
+      emitValue(nextValue, true);
+    },
+    [emitValue, range.maxValue, range.minValue, range.snapValue]
   );
 
-  const thumbStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
-  }));
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        onPanResponderGrant: () => {
+          isDraggingRef.current = true;
+          gestureStartRef.current = currentPositionRef.current;
+          onGestureStart?.();
+          triggerHaptic();
+        },
+        onPanResponderMove: (_, gestureState) => {
+          const nextPosition = clampPosition(
+            trackWidthRef.current,
+            gestureStartRef.current + gestureState.dx
+          );
+          setPosition(nextPosition);
 
-  const activeTrackStyle = useAnimatedStyle(() => ({
-    width: translateX.value,
-  }));
+          const nextValue = positionToValue(
+            trackWidthRef.current,
+            range.minValue,
+            range.maxValue,
+            range.snapValue,
+            nextPosition
+          );
+
+          if (nextValue !== lastEmittedValueRef.current) {
+            lastEmittedValueRef.current = nextValue;
+            onValueChange(nextValue);
+            triggerHaptic();
+          }
+        },
+        onPanResponderRelease: () => {
+          const finalValue = positionToValue(
+            trackWidthRef.current,
+            range.minValue,
+            range.maxValue,
+            range.snapValue,
+            currentPositionRef.current
+          );
+          isDraggingRef.current = false;
+          lastEmittedValueRef.current = finalValue;
+          animateToValue(finalValue);
+          onGestureEnd?.();
+        },
+        onPanResponderTerminate: () => {
+          isDraggingRef.current = false;
+          onGestureEnd?.();
+        },
+      }),
+    [
+      animateToValue,
+      onGestureEnd,
+      onGestureStart,
+      onValueChange,
+      range.maxValue,
+      range.minValue,
+      range.snapValue,
+      setPosition,
+      triggerHaptic,
+    ]
+  );
 
   return (
     <View style={styles.container}>
-      <GestureDetector gesture={sliderGesture}>
-        <View style={styles.sliderSurface}>
-          <View
-            style={[styles.trackContainer, { backgroundColor: colors.border }]}
-            onLayout={handleTrackLayout}
-          >
-            <View style={[styles.track, { backgroundColor: colors.border }]} />
-            <Animated.View
-              style={[
-                styles.activeTrack,
-                { backgroundColor: colors.tint },
-                activeTrackStyle,
-              ]}
-            />
-          </View>
+      <View style={styles.sliderSurface}>
+        <Pressable
+          onLayout={handleTrackLayout}
+          onPress={(event) => handleTrackPress(event.nativeEvent.locationX)}
+          style={[styles.trackContainer, { backgroundColor: colors.border }]}
+        >
+          <View style={[styles.track, { backgroundColor: colors.border }]} />
+          <Animated.View
+            style={[
+              styles.activeTrack,
+              { backgroundColor: colors.tint, width: position },
+            ]}
+          />
+        </Pressable>
 
-          <Animated.View style={[styles.thumbContainer, thumbStyle]}>
-            <View style={[styles.thumb, { borderColor: colors.tint }]} />
-          </Animated.View>
-        </View>
-      </GestureDetector>
+        <Animated.View
+          style={[styles.thumbContainer, { transform: [{ translateX: position }] }]}
+          {...panResponder.panHandlers}
+        >
+          <View style={[styles.thumb, { borderColor: colors.tint }]} />
+        </Animated.View>
+      </View>
     </View>
   );
 }

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -22,6 +22,24 @@ interface TimeSliderProps {
   interval?: number;
 }
 
+interface SliderRange {
+  minValue: number;
+  maxValue: number;
+  snapValue: number;
+}
+
+interface SliderPositionArgs {
+  position: number;
+  range: SliderRange;
+  trackWidth: number;
+}
+
+interface SliderValueArgs {
+  range: SliderRange;
+  trackWidth: number;
+  value: number;
+}
+
 const TRACK_HEIGHT = 8;
 const THUMB_SIZE = 32;
 const SPRING_CONFIG = { damping: 20, stiffness: 200, useNativeDriver: false };
@@ -77,24 +95,18 @@ function clampPosition(trackWidth: number, position: number) {
   return Math.max(0, Math.min(trackWidth, position));
 }
 
-function valueToPosition(trackWidth: number, minValue: number, maxValue: number, value: number) {
+function valueToPosition({ range, trackWidth, value }: SliderValueArgs) {
   if (trackWidth === 0) return 0;
-  const normalizedValue = (value - minValue) / (maxValue - minValue);
+  const normalizedValue = (value - range.minValue) / (range.maxValue - range.minValue);
   return normalizedValue * trackWidth;
 }
 
-function positionToValue(
-  trackWidth: number,
-  minValue: number,
-  maxValue: number,
-  snapValue: number,
-  position: number
-) {
-  if (trackWidth === 0) return minValue;
+function positionToValue({ position, range, trackWidth }: SliderPositionArgs) {
+  if (trackWidth === 0) return range.minValue;
   const normalizedPosition = position / trackWidth;
-  const rawValue = normalizedPosition * (maxValue - minValue) + minValue;
-  const constrained = getTimeInRange(rawValue, minValue, maxValue);
-  return snapToInterval(constrained, snapValue);
+  const rawValue = normalizedPosition * (range.maxValue - range.minValue) + range.minValue;
+  const constrained = getTimeInRange(rawValue, range.minValue, range.maxValue);
+  return snapToInterval(constrained, range.snapValue);
 }
 
 export function TimeSlider({
@@ -139,12 +151,11 @@ export function TimeSlider({
 
   const animateToValue = useCallback(
     (nextValue: number) => {
-      const nextPosition = valueToPosition(
-        trackWidthRef.current,
-        range.minValue,
-        range.maxValue,
-        nextValue
-      );
+      const nextPosition = valueToPosition({
+        trackWidth: trackWidthRef.current,
+        range,
+        value: nextValue,
+      });
       currentPositionRef.current = nextPosition;
       Animated.spring(position, {
         toValue: nextPosition,
@@ -189,16 +200,14 @@ export function TimeSlider({
 
   const handleTrackPress = useCallback(
     (locationX: number) => {
-      const nextValue = positionToValue(
-        trackWidthRef.current,
-        range.minValue,
-        range.maxValue,
-        range.snapValue,
-        clampPosition(trackWidthRef.current, locationX)
-      );
+      const nextValue = positionToValue({
+        trackWidth: trackWidthRef.current,
+        range,
+        position: clampPosition(trackWidthRef.current, locationX),
+      });
       emitValue(nextValue, true);
     },
-    [emitValue, range.maxValue, range.minValue, range.snapValue]
+    [emitValue, range]
   );
 
   const panResponder = useMemo(
@@ -219,13 +228,11 @@ export function TimeSlider({
           );
           setPosition(nextPosition);
 
-          const nextValue = positionToValue(
-            trackWidthRef.current,
-            range.minValue,
-            range.maxValue,
-            range.snapValue,
-            nextPosition
-          );
+          const nextValue = positionToValue({
+            trackWidth: trackWidthRef.current,
+            range,
+            position: nextPosition,
+          });
 
           if (nextValue !== lastEmittedValueRef.current) {
             lastEmittedValueRef.current = nextValue;
@@ -234,13 +241,11 @@ export function TimeSlider({
           }
         },
         onPanResponderRelease: () => {
-          const finalValue = positionToValue(
-            trackWidthRef.current,
-            range.minValue,
-            range.maxValue,
-            range.snapValue,
-            currentPositionRef.current
-          );
+          const finalValue = positionToValue({
+            trackWidth: trackWidthRef.current,
+            range,
+            position: currentPositionRef.current,
+          });
           isDraggingRef.current = false;
           lastEmittedValueRef.current = finalValue;
           animateToValue(finalValue);


### PR DESCRIPTION
## Summary

This PR fixes the slider runtime error on the flight setup screen and keeps the interaction model simple enough to behave reliably in Expo Go.

Users could reach the setup screen and scroll normally, but the duration slider still failed during interaction. The latest runtime error showed that the active track width was being animated through React Native's native animated module while `useNativeDriver` was enabled. React Native does not support animating `width` with the native driver, so the slider threw before it could be used.

## Root Cause

The slider implementation reused a single animated value for both horizontal thumb translation and active-track width. That part is fine on its own, but the spring animation was configured with `useNativeDriver: true`. Since `width` is not a transform property, React Native rejects that configuration at runtime.

## Fix

This branch replaces the custom gesture stack with a simpler React Native slider implementation that uses:

- `PanResponder` for thumb dragging
- `Pressable` for tapping the track
- `Animated.Value` for thumb position and active-track width
- `useNativeDriver: false` for the spring animation

That keeps the slider responsive while avoiding the unsupported native-driver width animation path.

## Validation

- `npx tsc --noEmit`
- `npm test -- --runInBand`
