### PR TITLE
[codex] Preload airport cache before fetching destinations

### DIFF
--- a/__tests__/screens/FlightSetupScreen.test.tsx
+++ b/__tests__/screens/FlightSetupScreen.test.tsx
@@ -6,10 +6,9 @@ import { loadAirports } from '@/services/airportService';
 import { getDestinationsByFlightTime, getDestinationsInTimeRange } from '@/services/radiusService';
 
 jest.mock('react-native', () => {
-  const React = require('react');
-
+  type HostProps = React.PropsWithChildren<Record<string, unknown>>;
   const createHostComponent = (name: string) => {
-    return ({ children, ...props }: any) => React.createElement(name, props, children);
+    return ({ children, ...props }: HostProps) => React.createElement(name, props, children);
   };
 
   return {
@@ -30,7 +29,6 @@ jest.mock('react-native', () => {
 
 jest.mock('@/components/airport/AirportCard', () => ({
   AirportCard: ({ airport }: { airport: { icao: string } }) => {
-    const React = require('react');
     return React.createElement('Text', { testID: 'home-airport' }, airport.icao);
   },
 }));
@@ -45,7 +43,6 @@ jest.mock('@/components/destinations/DestinationsList', () => ({
     isLoading: boolean;
     error: string | null;
   }) => {
-    const React = require('react');
     if (isLoading) {
       return React.createElement('Text', { testID: 'destinations-state' }, 'loading');
     }
@@ -63,7 +60,6 @@ jest.mock('@/components/destinations/DestinationsList', () => ({
 
 jest.mock('@/components/time-slider/TimeSlider', () => ({
   TimeSlider: ({ onValueChange }: { onValueChange: (value: number) => void }) => {
-    const React = require('react');
     return React.createElement(
       'Pressable',
       {
@@ -77,41 +73,36 @@ jest.mock('@/components/time-slider/TimeSlider', () => ({
 
 jest.mock('@/components/time-slider/TimeValue', () => ({
   TimeValue: ({ seconds }: { seconds: number }) => {
-    const React = require('react');
     return React.createElement('Text', { testID: 'time-value' }, String(seconds));
   },
 }));
 
 jest.mock('@/components/themed-text', () => ({
   ThemedText: ({ children }: { children: React.ReactNode }) => {
-    const React = require('react');
     return React.createElement('Text', null, children);
   },
 }));
 
 jest.mock('@/components/themed-view', () => ({
   ThemedView: ({ children }: { children: React.ReactNode }) => {
-    const React = require('react');
     return React.createElement('View', null, children);
   },
 }));
 
 jest.mock('@/components/ui/Button', () => ({
   Button: ({ title }: { title: string }) => {
-    const React = require('react');
     return React.createElement('Text', { testID: 'review-flight-button' }, title);
   },
 }));
 
 jest.mock('@/components/ui/icon-symbol', () => ({
   IconSymbol: () => {
-    const React = require('react');
     return React.createElement('Text', { testID: 'icon-symbol' }, 'icon');
   },
 }));
 
 jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn().mockResolvedValue(undefined),
+  impactAsync: jest.fn().mockImplementation(() => Promise.resolve()),
   ImpactFeedbackStyle: {
     Light: 'light',
     Heavy: 'heavy',
@@ -120,7 +111,6 @@ jest.mock('expo-haptics', () => ({
 
 jest.mock('react-native-safe-area-context', () => ({
   SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => {
-    const React = require('react');
     return React.createElement('SafeAreaView', props, children);
   },
 }));
@@ -208,7 +198,9 @@ const mockDestinations = [
   },
 ];
 
-function getText(renderer: any, testID: string) {
+type TestRendererInstance = ReturnType<typeof TestRenderer.create>;
+
+function getText(renderer: TestRendererInstance, testID: string) {
   return renderer.root.findByProps({ testID }).children.join('');
 }
 
@@ -216,7 +208,7 @@ describe('FlightSetupScreen', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
-    (loadAirports as jest.Mock).mockResolvedValue(undefined);
+    (loadAirports as jest.Mock).mockImplementation(() => Promise.resolve());
     (getDestinationsInTimeRange as jest.Mock).mockReturnValue([]);
     (getDestinationsByFlightTime as jest.Mock).mockImplementation((_origin, flightTime) => {
       return flightTime >= 10800 ? mockDestinations : mockDestinations.slice(0, 1);
@@ -228,7 +220,7 @@ describe('FlightSetupScreen', () => {
   });
 
   it('updates the available destinations after the slider changes', async () => {
-    let renderer: any;
+    let renderer: TestRendererInstance | null = null;
 
     act(() => {
       renderer = TestRenderer.create(<FlightSetupScreen />);
@@ -241,6 +233,10 @@ describe('FlightSetupScreen', () => {
     await act(async () => {
       await Promise.resolve();
     });
+
+    if (!renderer) {
+      throw new Error('Screen renderer not initialized');
+    }
 
     expect(getText(renderer, 'destinations-state')).toBe('Norman');
 
@@ -255,6 +251,10 @@ describe('FlightSetupScreen', () => {
     await act(async () => {
       await Promise.resolve();
     });
+
+    if (!renderer) {
+      throw new Error('Screen renderer not initialized');
+    }
 
     expect(getText(renderer, 'destinations-state')).toBe('Norman,Stillwater');
     expect(getDestinationsByFlightTime).toHaveBeenCalledWith(

--- a/__tests__/screens/FlightSetupScreen.test.tsx
+++ b/__tests__/screens/FlightSetupScreen.test.tsx
@@ -1,0 +1,265 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import FlightSetupScreen from '@/screens/FlightSetupScreen';
+import { loadAirports } from '@/services/airportService';
+import { getDestinationsByFlightTime, getDestinationsInTimeRange } from '@/services/radiusService';
+
+jest.mock('react-native', () => {
+  const React = require('react');
+
+  const createHostComponent = (name: string) => {
+    return ({ children, ...props }: any) => React.createElement(name, props, children);
+  };
+
+  return {
+    Platform: {
+      OS: 'ios',
+      select: (mapping: Record<string, unknown>) => mapping.ios ?? mapping.default,
+    },
+    View: createHostComponent('View'),
+    Text: createHostComponent('Text'),
+    Pressable: createHostComponent('Pressable'),
+    TouchableOpacity: createHostComponent('TouchableOpacity'),
+    SafeAreaView: createHostComponent('SafeAreaView'),
+    StyleSheet: {
+      create: (styles: Record<string, unknown>) => styles,
+    },
+  };
+});
+
+jest.mock('@/components/airport/AirportCard', () => ({
+  AirportCard: ({ airport }: { airport: { icao: string } }) => {
+    const React = require('react');
+    return React.createElement('Text', { testID: 'home-airport' }, airport.icao);
+  },
+}));
+
+jest.mock('@/components/destinations/DestinationsList', () => ({
+  DestinationsList: ({
+    destinations,
+    isLoading,
+    error,
+  }: {
+    destinations: Array<{ city: string }>;
+    isLoading: boolean;
+    error: string | null;
+  }) => {
+    const React = require('react');
+    if (isLoading) {
+      return React.createElement('Text', { testID: 'destinations-state' }, 'loading');
+    }
+    if (error) {
+      return React.createElement('Text', { testID: 'destinations-state' }, error);
+    }
+
+    return React.createElement(
+      'Text',
+      { testID: 'destinations-state' },
+      destinations.map((destination) => destination.city).join(',')
+    );
+  },
+}));
+
+jest.mock('@/components/time-slider/TimeSlider', () => ({
+  TimeSlider: ({ onValueChange }: { onValueChange: (value: number) => void }) => {
+    const React = require('react');
+    return React.createElement(
+      'Pressable',
+      {
+        testID: 'mock-time-slider',
+        onPress: () => onValueChange(10800),
+      },
+      React.createElement('Text', null, 'Mock Slider')
+    );
+  },
+}));
+
+jest.mock('@/components/time-slider/TimeValue', () => ({
+  TimeValue: ({ seconds }: { seconds: number }) => {
+    const React = require('react');
+    return React.createElement('Text', { testID: 'time-value' }, String(seconds));
+  },
+}));
+
+jest.mock('@/components/themed-text', () => ({
+  ThemedText: ({ children }: { children: React.ReactNode }) => {
+    const React = require('react');
+    return React.createElement('Text', null, children);
+  },
+}));
+
+jest.mock('@/components/themed-view', () => ({
+  ThemedView: ({ children }: { children: React.ReactNode }) => {
+    const React = require('react');
+    return React.createElement('View', null, children);
+  },
+}));
+
+jest.mock('@/components/ui/Button', () => ({
+  Button: ({ title }: { title: string }) => {
+    const React = require('react');
+    return React.createElement('Text', { testID: 'review-flight-button' }, title);
+  },
+}));
+
+jest.mock('@/components/ui/icon-symbol', () => ({
+  IconSymbol: () => {
+    const React = require('react');
+    return React.createElement('Text', { testID: 'icon-symbol' }, 'icon');
+  },
+}));
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: {
+    Light: 'light',
+    Heavy: 'heavy',
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => {
+    const React = require('react');
+    return React.createElement('SafeAreaView', props, children);
+  },
+}));
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('@/hooks/useHomeAirport', () => ({
+  useHomeAirport: () => ({
+    homeAirport: {
+      icao: 'KOKC',
+      iata: 'OKC',
+      name: 'Will Rogers World Airport',
+      city: 'Oklahoma City',
+      country: 'US',
+      state: 'OK',
+      lat: 35.3931,
+      lon: -97.6007,
+      elevation: 1295,
+      tz: 'America/Chicago',
+    },
+    isLoading: false,
+    handleSelectAirport: jest.fn(),
+    handleClearHomeBase: jest.fn(),
+    refreshHomeAirport: jest.fn(),
+  }),
+}));
+
+jest.mock('@/context/FlightContext', () => ({
+  useFlight: () => ({
+    origin: null,
+    destination: null,
+    flightDuration: 3600,
+    setOrigin: jest.fn(),
+    setDestination: jest.fn(),
+    setFlightDuration: jest.fn(),
+  }),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    back: jest.fn(),
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock('@/services/airportService', () => ({
+  loadAirports: jest.fn(),
+}));
+
+jest.mock('@/services/radiusService', () => ({
+  getDestinationsByFlightTime: jest.fn(),
+  getDestinationsInTimeRange: jest.fn(),
+}));
+
+const mockDestinations = [
+  {
+    icao: 'KOUN',
+    iata: 'OUN',
+    name: 'University of Oklahoma Westheimer Airport',
+    city: 'Norman',
+    country: 'US',
+    state: 'OK',
+    lat: 35.2456,
+    lon: -97.4721,
+    elevation: 1162,
+    tz: 'America/Chicago',
+    distance: 20,
+    flightTime: 2400,
+  },
+  {
+    icao: 'KSWO',
+    iata: 'SWO',
+    name: 'Stillwater Regional Airport',
+    city: 'Stillwater',
+    country: 'US',
+    state: 'OK',
+    lat: 36.1612,
+    lon: -97.0857,
+    elevation: 1000,
+    tz: 'America/Chicago',
+    distance: 45,
+    flightTime: 4800,
+  },
+];
+
+function getText(renderer: any, testID: string) {
+  return renderer.root.findByProps({ testID }).children.join('');
+}
+
+describe('FlightSetupScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    (loadAirports as jest.Mock).mockResolvedValue(undefined);
+    (getDestinationsInTimeRange as jest.Mock).mockReturnValue([]);
+    (getDestinationsByFlightTime as jest.Mock).mockImplementation((_origin, flightTime) => {
+      return flightTime >= 10800 ? mockDestinations : mockDestinations.slice(0, 1);
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('updates the available destinations after the slider changes', async () => {
+    let renderer: any;
+
+    act(() => {
+      renderer = TestRenderer.create(<FlightSetupScreen />);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getText(renderer, 'destinations-state')).toBe('Norman');
+
+    act(() => {
+      renderer.root.findByProps({ testID: 'mock-time-slider' }).props.onPress();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getText(renderer, 'destinations-state')).toBe('Norman,Stillwater');
+    expect(getDestinationsByFlightTime).toHaveBeenCalledWith(
+      { lat: 35.3931, lon: -97.6007 },
+      10800
+    );
+  });
+});

--- a/__tests__/services/useDestinations.test.ts
+++ b/__tests__/services/useDestinations.test.ts
@@ -1,0 +1,152 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import { useDestinations } from '@/hooks/useDestinations';
+import { loadAirports } from '@/services/airportService';
+import { getDestinationsByFlightTime, getDestinationsInTimeRange } from '@/services/radiusService';
+import type { Airport } from '@/types/airport';
+import type { AirportWithFlightTime } from '@/types/radius';
+
+jest.mock('@/services/airportService', () => ({
+  loadAirports: jest.fn(),
+}));
+
+jest.mock('@/services/radiusService', () => ({
+  getDestinationsByFlightTime: jest.fn(),
+  getDestinationsInTimeRange: jest.fn(),
+}));
+
+const mockOrigin: Airport = {
+  icao: 'KOKC',
+  iata: 'OKC',
+  name: 'Will Rogers World Airport',
+  city: 'Oklahoma City',
+  country: 'US',
+  state: 'OK',
+  lat: 35.3931,
+  lon: -97.6007,
+  elevation: 1295,
+  tz: 'America/Chicago',
+};
+
+const mockDestinations: AirportWithFlightTime[] = [
+  {
+    icao: 'KDFW',
+    iata: 'DFW',
+    name: 'Dallas/Fort Worth International Airport',
+    city: 'Dallas-Fort Worth',
+    country: 'US',
+    state: 'TX',
+    lat: 32.8998,
+    lon: -97.0403,
+    elevation: 607,
+    tz: 'America/Chicago',
+    flightTime: 7200,
+    distance: 180,
+  },
+];
+
+function renderUseDestinations({
+  origin,
+  flightTimeInSeconds,
+  useTimeRange,
+  debounceMs,
+}: Parameters<typeof useDestinations>[0]) {
+  let latestResult: ReturnType<typeof useDestinations> | null = null;
+  let renderer: any;
+
+  function Harness(props: Parameters<typeof useDestinations>[0]) {
+    latestResult = useDestinations(props);
+    return null;
+  }
+
+  act(() => {
+    renderer = TestRenderer.create(
+      React.createElement(Harness, {
+        origin,
+        flightTimeInSeconds,
+        useTimeRange,
+        debounceMs,
+      })
+    );
+  });
+
+  return {
+    get current() {
+      if (!latestResult) {
+        throw new Error('Hook result not ready');
+      }
+      return latestResult;
+    },
+    rerender(nextProps: Parameters<typeof useDestinations>[0]) {
+      act(() => {
+        renderer.update(React.createElement(Harness, nextProps));
+      });
+    },
+    unmount() {
+      act(() => {
+        renderer.unmount();
+      });
+    },
+  };
+}
+
+describe('useDestinations', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    (loadAirports as jest.Mock).mockResolvedValue(undefined);
+    (getDestinationsByFlightTime as jest.Mock).mockReturnValue(mockDestinations);
+    (getDestinationsInTimeRange as jest.Mock).mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('loads the airport cache before calculating destinations', async () => {
+    let resolveLoadAirports: (() => void) | null = null;
+    (loadAirports as jest.Mock).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoadAirports = resolve;
+        })
+    );
+
+    const hook = renderUseDestinations({
+      origin: mockOrigin,
+      flightTimeInSeconds: 7200,
+      useTimeRange: false,
+      debounceMs: 5,
+    });
+
+    expect(hook.current.isLoading).toBe(false);
+    expect(hook.current.destinations).toEqual([]);
+
+    act(() => {
+      jest.advanceTimersByTime(5);
+    });
+
+    expect(loadAirports).toHaveBeenCalledTimes(1);
+    expect(hook.current.isLoading).toBe(true);
+    expect(getDestinationsByFlightTime).not.toHaveBeenCalled();
+
+    act(() => {
+      resolveLoadAirports?.();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getDestinationsByFlightTime).toHaveBeenCalledTimes(1);
+    expect(getDestinationsByFlightTime).toHaveBeenCalledWith(
+      { lat: mockOrigin.lat, lon: mockOrigin.lon },
+      7200
+    );
+    expect(hook.current.destinations).toEqual(mockDestinations);
+    expect(hook.current.isLoading).toBe(false);
+
+    hook.unmount();
+  });
+});

--- a/__tests__/services/useDestinations.test.ts
+++ b/__tests__/services/useDestinations.test.ts
@@ -46,16 +46,19 @@ const mockDestinations: AirportWithFlightTime[] = [
   },
 ];
 
+type UseDestinationsProps = Parameters<typeof useDestinations>[0];
+type TestRendererInstance = ReturnType<typeof TestRenderer.create>;
+
 function renderUseDestinations({
   origin,
   flightTimeInSeconds,
   useTimeRange,
   debounceMs,
-}: Parameters<typeof useDestinations>[0]) {
+}: UseDestinationsProps) {
   let latestResult: ReturnType<typeof useDestinations> | null = null;
-  let renderer: any;
+  let renderer: TestRendererInstance | null = null;
 
-  function Harness(props: Parameters<typeof useDestinations>[0]) {
+  function Harness(props: UseDestinationsProps) {
     latestResult = useDestinations(props);
     return null;
   }
@@ -78,13 +81,21 @@ function renderUseDestinations({
       }
       return latestResult;
     },
-    rerender(nextProps: Parameters<typeof useDestinations>[0]) {
+    rerender(nextProps: UseDestinationsProps) {
       act(() => {
+        if (!renderer) {
+          throw new Error('Hook renderer not initialized');
+        }
+
         renderer.update(React.createElement(Harness, nextProps));
       });
     },
     unmount() {
       act(() => {
+        if (!renderer) {
+          throw new Error('Hook renderer not initialized');
+        }
+
         renderer.unmount();
       });
     },
@@ -95,7 +106,7 @@ describe('useDestinations', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
-    (loadAirports as jest.Mock).mockResolvedValue(undefined);
+    (loadAirports as jest.Mock).mockImplementation(() => Promise.resolve());
     (getDestinationsByFlightTime as jest.Mock).mockReturnValue(mockDestinations);
     (getDestinationsInTimeRange as jest.Mock).mockReturnValue([]);
   });

--- a/__tests__/services/useDestinations.test.ts
+++ b/__tests__/services/useDestinations.test.ts
@@ -160,4 +160,37 @@ describe('useDestinations', () => {
 
     hook.unmount();
   });
+
+  it('ignores in-flight destination work after unmount', async () => {
+    let resolveLoadAirports: (() => void) | null = null;
+    (loadAirports as jest.Mock).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoadAirports = resolve;
+        })
+    );
+
+    const hook = renderUseDestinations({
+      origin: mockOrigin,
+      flightTimeInSeconds: 7200,
+      useTimeRange: false,
+      debounceMs: 5,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5);
+    });
+
+    hook.unmount();
+
+    act(() => {
+      resolveLoadAirports?.();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getDestinationsByFlightTime).not.toHaveBeenCalled();
+  });
 });

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -162,7 +162,7 @@ export function TimeSlider({
         ...SPRING_CONFIG,
       }).start();
     },
-    [position, range.maxValue, range.minValue]
+    [position, range]
   );
 
   const emitValue = useCallback(
@@ -217,7 +217,10 @@ export function TimeSlider({
         onMoveShouldSetPanResponder: () => true,
         onPanResponderGrant: () => {
           isDraggingRef.current = true;
-          gestureStartRef.current = currentPositionRef.current;
+          position.stopAnimation((animatedPosition) => {
+            currentPositionRef.current = animatedPosition;
+            gestureStartRef.current = animatedPosition;
+          });
           onGestureStart?.();
           triggerHaptic();
         },
@@ -261,9 +264,8 @@ export function TimeSlider({
       onGestureEnd,
       onGestureStart,
       onValueChange,
-      range.maxValue,
-      range.minValue,
-      range.snapValue,
+      position,
+      range,
       setPosition,
       triggerHaptic,
     ]

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -42,7 +42,8 @@ interface SliderValueArgs {
 
 const TRACK_HEIGHT = 8;
 const THUMB_SIZE = 32;
-const SPRING_CONFIG = { damping: 20, stiffness: 200, useNativeDriver: false };
+const THUMB_SPRING_CONFIG = { damping: 20, stiffness: 200, useNativeDriver: true };
+const TRACK_SPRING_CONFIG = { damping: 20, stiffness: 200, useNativeDriver: false };
 
 const styles = StyleSheet.create({
   container: {
@@ -97,7 +98,9 @@ function clampPosition(trackWidth: number, position: number) {
 
 function valueToPosition({ range, trackWidth, value }: SliderValueArgs) {
   if (trackWidth === 0) return 0;
-  const normalizedValue = (value - range.minValue) / (range.maxValue - range.minValue);
+  const constrainedValue = getTimeInRange(value, range.minValue, range.maxValue);
+  const normalizedValue =
+    (constrainedValue - range.minValue) / (range.maxValue - range.minValue);
   return normalizedValue * trackWidth;
 }
 
@@ -130,7 +133,8 @@ export function TimeSlider({
     [defaultRange.interval, defaultRange.max, defaultRange.min, interval, max, min]
   );
 
-  const position = useRef(new Animated.Value(0)).current;
+  const thumbPosition = useRef(new Animated.Value(0)).current;
+  const activeTrackWidth = useRef(new Animated.Value(0)).current;
   const trackWidthRef = useRef(0);
   const currentPositionRef = useRef(0);
   const gestureStartRef = useRef(0);
@@ -144,9 +148,10 @@ export function TimeSlider({
   const setPosition = useCallback(
     (nextPosition: number) => {
       currentPositionRef.current = nextPosition;
-      position.setValue(nextPosition);
+      thumbPosition.setValue(nextPosition);
+      activeTrackWidth.setValue(nextPosition);
     },
-    [position]
+    [activeTrackWidth, thumbPosition]
   );
 
   const animateToValue = useCallback(
@@ -157,12 +162,18 @@ export function TimeSlider({
         value: nextValue,
       });
       currentPositionRef.current = nextPosition;
-      Animated.spring(position, {
-        toValue: nextPosition,
-        ...SPRING_CONFIG,
-      }).start();
+      Animated.parallel([
+        Animated.spring(thumbPosition, {
+          toValue: nextPosition,
+          ...THUMB_SPRING_CONFIG,
+        }),
+        Animated.spring(activeTrackWidth, {
+          toValue: nextPosition,
+          ...TRACK_SPRING_CONFIG,
+        }),
+      ]).start();
     },
-    [position, range]
+    [activeTrackWidth, range, thumbPosition]
   );
 
   const emitValue = useCallback(
@@ -217,7 +228,7 @@ export function TimeSlider({
         onMoveShouldSetPanResponder: () => true,
         onPanResponderGrant: () => {
           isDraggingRef.current = true;
-          position.stopAnimation((animatedPosition) => {
+          thumbPosition.stopAnimation((animatedPosition) => {
             currentPositionRef.current = animatedPosition;
             gestureStartRef.current = animatedPosition;
           });
@@ -255,7 +266,14 @@ export function TimeSlider({
           onGestureEnd?.();
         },
         onPanResponderTerminate: () => {
+          const finalValue = positionToValue({
+            trackWidth: trackWidthRef.current,
+            range,
+            position: currentPositionRef.current,
+          });
           isDraggingRef.current = false;
+          lastEmittedValueRef.current = finalValue;
+          animateToValue(finalValue);
           onGestureEnd?.();
         },
       }),
@@ -264,10 +282,10 @@ export function TimeSlider({
       onGestureEnd,
       onGestureStart,
       onValueChange,
-      position,
       range,
       setPosition,
       triggerHaptic,
+      thumbPosition,
     ]
   );
 
@@ -283,13 +301,13 @@ export function TimeSlider({
           <Animated.View
             style={[
               styles.activeTrack,
-              { backgroundColor: colors.tint, width: position },
+              { backgroundColor: colors.tint, width: activeTrackWidth },
             ]}
           />
         </Pressable>
 
         <Animated.View
-          style={[styles.thumbContainer, { transform: [{ translateX: position }] }]}
+          style={[styles.thumbContainer, { transform: [{ translateX: thumbPosition }] }]}
           {...panResponder.panHandlers}
         >
           <View style={[styles.thumb, { borderColor: colors.tint }]} />

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -2,45 +2,35 @@ import { Colors, Spacing } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { getDefaultTimeRange, getTimeInRange, snapToInterval } from "@/utils/timeSlider";
 import { impactAsync, ImpactFeedbackStyle } from "expo-haptics";
-import { useCallback, useEffect, useMemo } from "react";
-import { LayoutChangeEvent, StyleSheet, View } from "react-native";
-import { Gesture, GestureDetector } from "react-native-gesture-handler";
-import Animated, {
-  runOnJS,
-  SharedValue,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-} from "react-native-reanimated";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  Animated,
+  LayoutChangeEvent,
+  PanResponder,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
 
 interface TimeSliderProps {
-  /** Current time value in seconds */
   value: number;
-  /** Callback when value changes */
   onValueChange: (value: number) => void;
-  /** Callback when gesture starts */
   onGestureStart?: () => void;
-  /** Callback when gesture ends */
   onGestureEnd?: () => void;
-  /** Minimum time in seconds (default: 30min) */
   min?: number;
-  /** Maximum time in seconds (default: 5h) */
   max?: number;
-  /** Snap interval in seconds (default: 10min) */
   interval?: number;
 }
 
 const TRACK_HEIGHT = 8;
 const THUMB_SIZE = 32;
-const HIT_SLOP = { top: 20, bottom: 20, left: 10, right: 10 };
-const SPRING_CONFIG = { damping: 20, stiffness: 200 };
+const SPRING_CONFIG = { damping: 20, stiffness: 200, useNativeDriver: false };
 
 const styles = StyleSheet.create({
   container: {
     width: "100%",
     paddingHorizontal: Spacing.md,
     paddingVertical: Spacing.lg,
-    position: "relative",
   },
   sliderSurface: {
     height: THUMB_SIZE,
@@ -50,7 +40,6 @@ const styles = StyleSheet.create({
     height: TRACK_HEIGHT,
     borderRadius: TRACK_HEIGHT / 2,
     overflow: "hidden",
-    position: "relative",
   },
   track: {
     flex: 1,
@@ -84,116 +73,28 @@ const styles = StyleSheet.create({
   },
 });
 
-interface SliderRange {
-  minValue: number;
-  maxValue: number;
-  snapValue: number;
+function clampPosition(trackWidth: number, position: number) {
+  return Math.max(0, Math.min(trackWidth, position));
 }
 
-interface SliderSharedState {
-  gestureStartX: SharedValue<number>;
-  isGestureActive: SharedValue<boolean>;
-  lastEmittedValue: SharedValue<number>;
-  trackWidth: SharedValue<number>;
-  translateX: SharedValue<number>;
+function valueToPosition(trackWidth: number, minValue: number, maxValue: number, value: number) {
+  if (trackWidth === 0) return 0;
+  const normalizedValue = (value - minValue) / (maxValue - minValue);
+  return normalizedValue * trackWidth;
 }
 
-function useSliderSharedState(value: number): SliderSharedState {
-  return {
-    trackWidth: useSharedValue(0),
-    translateX: useSharedValue(0),
-    gestureStartX: useSharedValue(0),
-    isGestureActive: useSharedValue(false),
-    lastEmittedValue: useSharedValue(value),
-  };
-}
-
-function clampPosition(trackWidth: SharedValue<number>, position: number) {
-  "worklet";
-  return Math.max(0, Math.min(trackWidth.value, position));
-}
-
-function valueToPosition(trackWidth: SharedValue<number>, range: SliderRange, value: number) {
-  "worklet";
-  if (trackWidth.value === 0) return 0;
-  const normalizedValue = (value - range.minValue) / (range.maxValue - range.minValue);
-  return normalizedValue * trackWidth.value;
-}
-
-function positionToValue(trackWidth: SharedValue<number>, range: SliderRange, position: number) {
-  "worklet";
-  if (trackWidth.value === 0) return range.minValue;
-  const normalizedPosition = position / trackWidth.value;
-  const rawValue = normalizedPosition * (range.maxValue - range.minValue) + range.minValue;
-  const constrained = getTimeInRange(rawValue, range.minValue, range.maxValue);
-  return snapToInterval(constrained, range.snapValue);
-}
-
-function createSliderGestures(
-  range: SliderRange,
-  shared: SliderSharedState,
-  onGestureStart: (() => void) | undefined,
-  onGestureEnd: (() => void) | undefined,
-  onValueChange: (value: number) => void,
-  triggerHaptic: () => void
+function positionToValue(
+  trackWidth: number,
+  minValue: number,
+  maxValue: number,
+  snapValue: number,
+  position: number
 ) {
-  const panGesture = Gesture.Pan()
-    .onBegin(() => {
-      shared.isGestureActive.value = true;
-      shared.gestureStartX.value = shared.translateX.value;
-      if (onGestureStart) {
-        runOnJS(onGestureStart)();
-      }
-      runOnJS(triggerHaptic)();
-    })
-    .onUpdate((event) => {
-      const nextPosition = clampPosition(shared.trackWidth, shared.gestureStartX.value + event.translationX);
-      shared.translateX.value = nextPosition;
-
-      const nextValue = positionToValue(shared.trackWidth, range, nextPosition);
-      if (nextValue !== shared.lastEmittedValue.value) {
-        shared.lastEmittedValue.value = nextValue;
-        runOnJS(onValueChange)(nextValue);
-        runOnJS(triggerHaptic)();
-      }
-    })
-    .onEnd(() => {
-      const finalValue = positionToValue(shared.trackWidth, range, shared.translateX.value);
-      shared.lastEmittedValue.value = finalValue;
-      shared.translateX.value = withSpring(
-        valueToPosition(shared.trackWidth, range, finalValue),
-        SPRING_CONFIG
-      );
-      shared.isGestureActive.value = false;
-
-      if (onGestureEnd) {
-        runOnJS(onGestureEnd)();
-      }
-    })
-    .hitSlop(HIT_SLOP);
-
-  const tapGesture = Gesture.Tap().onEnd((event) => {
-    const nextValue = positionToValue(
-      shared.trackWidth,
-      range,
-      clampPosition(shared.trackWidth, event.x)
-    );
-    if (nextValue === shared.lastEmittedValue.value) {
-      return;
-    }
-
-    shared.isGestureActive.value = false;
-    shared.lastEmittedValue.value = nextValue;
-    shared.translateX.value = withSpring(
-      valueToPosition(shared.trackWidth, range, nextValue),
-      SPRING_CONFIG
-    );
-
-    runOnJS(onValueChange)(nextValue);
-    runOnJS(triggerHaptic)();
-  });
-
-  return Gesture.Simultaneous(panGesture, tapGesture);
+  if (trackWidth === 0) return minValue;
+  const normalizedPosition = position / trackWidth;
+  const rawValue = normalizedPosition * (maxValue - minValue) + minValue;
+  const constrained = getTimeInRange(rawValue, minValue, maxValue);
+  return snapToInterval(constrained, snapValue);
 }
 
 export function TimeSlider({
@@ -210,83 +111,183 @@ export function TimeSlider({
   const defaultRange = getDefaultTimeRange();
   const range = useMemo(
     () => ({
-    minValue: min ?? defaultRange.min,
-    maxValue: max ?? defaultRange.max,
-    snapValue: interval ?? defaultRange.interval,
+      minValue: min ?? defaultRange.min,
+      maxValue: max ?? defaultRange.max,
+      snapValue: interval ?? defaultRange.interval,
     }),
     [defaultRange.interval, defaultRange.max, defaultRange.min, interval, max, min]
   );
-  const {
-    gestureStartX,
-    isGestureActive,
-    lastEmittedValue,
-    trackWidth,
-    translateX,
-  } = useSliderSharedState(value);
+
+  const position = useRef(new Animated.Value(0)).current;
+  const trackWidthRef = useRef(0);
+  const currentPositionRef = useRef(0);
+  const gestureStartRef = useRef(0);
+  const isDraggingRef = useRef(false);
+  const lastEmittedValueRef = useRef(value);
 
   const triggerHaptic = useCallback(() => {
     impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
   }, []);
 
-  useEffect(() => {
-    if (!isGestureActive.value) {
-      lastEmittedValue.value = value;
-      translateX.value = withSpring(
-        valueToPosition(trackWidth, range, value),
-        SPRING_CONFIG
+  const setPosition = useCallback(
+    (nextPosition: number) => {
+      currentPositionRef.current = nextPosition;
+      position.setValue(nextPosition);
+    },
+    [position]
+  );
+
+  const animateToValue = useCallback(
+    (nextValue: number) => {
+      const nextPosition = valueToPosition(
+        trackWidthRef.current,
+        range.minValue,
+        range.maxValue,
+        nextValue
       );
+      currentPositionRef.current = nextPosition;
+      Animated.spring(position, {
+        toValue: nextPosition,
+        ...SPRING_CONFIG,
+      }).start();
+    },
+    [position, range.maxValue, range.minValue]
+  );
+
+  const emitValue = useCallback(
+    (nextValue: number, withHaptic: boolean) => {
+      if (nextValue === lastEmittedValueRef.current) {
+        return;
+      }
+
+      lastEmittedValueRef.current = nextValue;
+      animateToValue(nextValue);
+      onValueChange(nextValue);
+      if (withHaptic) {
+        triggerHaptic();
+      }
+    },
+    [animateToValue, onValueChange, triggerHaptic]
+  );
+
+  useEffect(() => {
+    if (isDraggingRef.current) {
+      return;
     }
-  }, [isGestureActive, lastEmittedValue, range, trackWidth, translateX, value]);
+
+    lastEmittedValueRef.current = value;
+    animateToValue(value);
+  }, [animateToValue, value]);
 
   const handleTrackLayout = useCallback(
     (event: LayoutChangeEvent) => {
-      const { width } = event.nativeEvent.layout;
-      trackWidth.value = width;
-      translateX.value = valueToPosition(trackWidth, range, value);
+      trackWidthRef.current = event.nativeEvent.layout.width;
+      animateToValue(lastEmittedValueRef.current);
     },
-    [range, trackWidth, translateX, value]
+    [animateToValue]
   );
 
-  const sliderGesture = createSliderGestures(
-    range,
-    { gestureStartX, isGestureActive, lastEmittedValue, trackWidth, translateX },
-    onGestureStart,
-    onGestureEnd,
-    onValueChange,
-    triggerHaptic
+  const handleTrackPress = useCallback(
+    (locationX: number) => {
+      const nextValue = positionToValue(
+        trackWidthRef.current,
+        range.minValue,
+        range.maxValue,
+        range.snapValue,
+        clampPosition(trackWidthRef.current, locationX)
+      );
+      emitValue(nextValue, true);
+    },
+    [emitValue, range.maxValue, range.minValue, range.snapValue]
   );
 
-  const thumbStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
-  }));
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        onPanResponderGrant: () => {
+          isDraggingRef.current = true;
+          gestureStartRef.current = currentPositionRef.current;
+          onGestureStart?.();
+          triggerHaptic();
+        },
+        onPanResponderMove: (_, gestureState) => {
+          const nextPosition = clampPosition(
+            trackWidthRef.current,
+            gestureStartRef.current + gestureState.dx
+          );
+          setPosition(nextPosition);
 
-  const activeTrackStyle = useAnimatedStyle(() => ({
-    width: translateX.value,
-  }));
+          const nextValue = positionToValue(
+            trackWidthRef.current,
+            range.minValue,
+            range.maxValue,
+            range.snapValue,
+            nextPosition
+          );
+
+          if (nextValue !== lastEmittedValueRef.current) {
+            lastEmittedValueRef.current = nextValue;
+            onValueChange(nextValue);
+            triggerHaptic();
+          }
+        },
+        onPanResponderRelease: () => {
+          const finalValue = positionToValue(
+            trackWidthRef.current,
+            range.minValue,
+            range.maxValue,
+            range.snapValue,
+            currentPositionRef.current
+          );
+          isDraggingRef.current = false;
+          lastEmittedValueRef.current = finalValue;
+          animateToValue(finalValue);
+          onGestureEnd?.();
+        },
+        onPanResponderTerminate: () => {
+          isDraggingRef.current = false;
+          onGestureEnd?.();
+        },
+      }),
+    [
+      animateToValue,
+      onGestureEnd,
+      onGestureStart,
+      onValueChange,
+      range.maxValue,
+      range.minValue,
+      range.snapValue,
+      setPosition,
+      triggerHaptic,
+    ]
+  );
 
   return (
     <View style={styles.container}>
-      <GestureDetector gesture={sliderGesture}>
-        <View style={styles.sliderSurface}>
-          <View
-            style={[styles.trackContainer, { backgroundColor: colors.border }]}
-            onLayout={handleTrackLayout}
-          >
-            <View style={[styles.track, { backgroundColor: colors.border }]} />
-            <Animated.View
-              style={[
-                styles.activeTrack,
-                { backgroundColor: colors.tint },
-                activeTrackStyle,
-              ]}
-            />
-          </View>
+      <View style={styles.sliderSurface}>
+        <Pressable
+          onLayout={handleTrackLayout}
+          onPress={(event) => handleTrackPress(event.nativeEvent.locationX)}
+          style={[styles.trackContainer, { backgroundColor: colors.border }]}
+        >
+          <View style={[styles.track, { backgroundColor: colors.border }]} />
+          <Animated.View
+            style={[
+              styles.activeTrack,
+              { backgroundColor: colors.tint, width: position },
+            ]}
+          />
+        </Pressable>
 
-          <Animated.View style={[styles.thumbContainer, thumbStyle]}>
-            <View style={[styles.thumb, { borderColor: colors.tint }]} />
-          </Animated.View>
-        </View>
-      </GestureDetector>
+        <Animated.View
+          style={[styles.thumbContainer, { transform: [{ translateX: position }] }]}
+          {...panResponder.panHandlers}
+        >
+          <View style={[styles.thumb, { borderColor: colors.tint }]} />
+        </Animated.View>
+      </View>
     </View>
   );
 }

--- a/components/time-slider/TimeSlider.tsx
+++ b/components/time-slider/TimeSlider.tsx
@@ -22,6 +22,24 @@ interface TimeSliderProps {
   interval?: number;
 }
 
+interface SliderRange {
+  minValue: number;
+  maxValue: number;
+  snapValue: number;
+}
+
+interface SliderPositionArgs {
+  position: number;
+  range: SliderRange;
+  trackWidth: number;
+}
+
+interface SliderValueArgs {
+  range: SliderRange;
+  trackWidth: number;
+  value: number;
+}
+
 const TRACK_HEIGHT = 8;
 const THUMB_SIZE = 32;
 const SPRING_CONFIG = { damping: 20, stiffness: 200, useNativeDriver: false };
@@ -77,24 +95,18 @@ function clampPosition(trackWidth: number, position: number) {
   return Math.max(0, Math.min(trackWidth, position));
 }
 
-function valueToPosition(trackWidth: number, minValue: number, maxValue: number, value: number) {
+function valueToPosition({ range, trackWidth, value }: SliderValueArgs) {
   if (trackWidth === 0) return 0;
-  const normalizedValue = (value - minValue) / (maxValue - minValue);
+  const normalizedValue = (value - range.minValue) / (range.maxValue - range.minValue);
   return normalizedValue * trackWidth;
 }
 
-function positionToValue(
-  trackWidth: number,
-  minValue: number,
-  maxValue: number,
-  snapValue: number,
-  position: number
-) {
-  if (trackWidth === 0) return minValue;
+function positionToValue({ position, range, trackWidth }: SliderPositionArgs) {
+  if (trackWidth === 0) return range.minValue;
   const normalizedPosition = position / trackWidth;
-  const rawValue = normalizedPosition * (maxValue - minValue) + minValue;
-  const constrained = getTimeInRange(rawValue, minValue, maxValue);
-  return snapToInterval(constrained, snapValue);
+  const rawValue = normalizedPosition * (range.maxValue - range.minValue) + range.minValue;
+  const constrained = getTimeInRange(rawValue, range.minValue, range.maxValue);
+  return snapToInterval(constrained, range.snapValue);
 }
 
 export function TimeSlider({
@@ -139,12 +151,11 @@ export function TimeSlider({
 
   const animateToValue = useCallback(
     (nextValue: number) => {
-      const nextPosition = valueToPosition(
-        trackWidthRef.current,
-        range.minValue,
-        range.maxValue,
-        nextValue
-      );
+      const nextPosition = valueToPosition({
+        trackWidth: trackWidthRef.current,
+        range,
+        value: nextValue,
+      });
       currentPositionRef.current = nextPosition;
       Animated.spring(position, {
         toValue: nextPosition,
@@ -189,16 +200,14 @@ export function TimeSlider({
 
   const handleTrackPress = useCallback(
     (locationX: number) => {
-      const nextValue = positionToValue(
-        trackWidthRef.current,
-        range.minValue,
-        range.maxValue,
-        range.snapValue,
-        clampPosition(trackWidthRef.current, locationX)
-      );
+      const nextValue = positionToValue({
+        trackWidth: trackWidthRef.current,
+        range,
+        position: clampPosition(trackWidthRef.current, locationX),
+      });
       emitValue(nextValue, true);
     },
-    [emitValue, range.maxValue, range.minValue, range.snapValue]
+    [emitValue, range]
   );
 
   const panResponder = useMemo(
@@ -219,13 +228,11 @@ export function TimeSlider({
           );
           setPosition(nextPosition);
 
-          const nextValue = positionToValue(
-            trackWidthRef.current,
-            range.minValue,
-            range.maxValue,
-            range.snapValue,
-            nextPosition
-          );
+          const nextValue = positionToValue({
+            trackWidth: trackWidthRef.current,
+            range,
+            position: nextPosition,
+          });
 
           if (nextValue !== lastEmittedValueRef.current) {
             lastEmittedValueRef.current = nextValue;
@@ -234,13 +241,11 @@ export function TimeSlider({
           }
         },
         onPanResponderRelease: () => {
-          const finalValue = positionToValue(
-            trackWidthRef.current,
-            range.minValue,
-            range.maxValue,
-            range.snapValue,
-            currentPositionRef.current
-          );
+          const finalValue = positionToValue({
+            trackWidth: trackWidthRef.current,
+            range,
+            position: currentPositionRef.current,
+          });
           isDraggingRef.current = false;
           lastEmittedValueRef.current = finalValue;
           animateToValue(finalValue);

--- a/hooks/useDestinations.ts
+++ b/hooks/useDestinations.ts
@@ -74,6 +74,17 @@ export function useDestinations({
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const requestIdRef = useRef(0);
 
+  useEffect(() => {
+    return () => {
+      requestIdRef.current += 1;
+
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+  }, []);
+
   // Convert origin to coordinates
   const originCoords: Coordinates | null = useMemo(() => {
     if (!origin) return null;

--- a/hooks/useDestinations.ts
+++ b/hooks/useDestinations.ts
@@ -112,10 +112,6 @@ export function useDestinations({
         results = getDestinationsByFlightTime(originCoords, flightTimeInSeconds);
       }
 
-      if (requestId !== requestIdRef.current) {
-        return;
-      }
-
       setDestinations(results);
       setError(null);
     } catch (err) {
@@ -126,11 +122,9 @@ export function useDestinations({
       setError(err instanceof Error ? err.message : "Failed to fetch destinations");
       setDestinations([]);
     } finally {
-      if (requestId !== requestIdRef.current) {
-        return;
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
       }
-
-      setIsLoading(false);
     }
   }, [originCoords, flightTimeInSeconds, useTimeRange, tolerance]);
 
@@ -143,7 +137,7 @@ export function useDestinations({
 
     // Set new timer
     const timer = setTimeout(() => {
-      void fetchDestinations();
+      fetchDestinations();
     }, debounceMs);
 
     debounceTimerRef.current = timer;
@@ -158,7 +152,7 @@ export function useDestinations({
   }, [debounceMs, fetchDestinations]);
 
   const refresh = useCallback(() => {
-    void fetchDestinations();
+    fetchDestinations();
   }, [fetchDestinations]);
 
   return {

--- a/hooks/useDestinations.ts
+++ b/hooks/useDestinations.ts
@@ -5,10 +5,11 @@
  */
 
 import { getDestinationsByFlightTime, getDestinationsInTimeRange } from "@/services/radiusService";
+import { loadAirports } from "@/services/airportService";
 import { Airport } from "@/types/airport";
 import { Coordinates } from "@/types/location";
 import { AirportWithFlightTime } from "@/types/radius";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface UseDestinationsOptions {
   /** Origin airport */
@@ -70,7 +71,8 @@ export function useDestinations({
   const [destinations, setDestinations] = useState<AirportWithFlightTime[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [debounceTimer, setDebounceTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestIdRef = useRef(0);
 
   // Convert origin to coordinates
   const originCoords: Coordinates | null = useMemo(() => {
@@ -79,7 +81,9 @@ export function useDestinations({
   }, [origin]);
 
   // Fetch destinations
-  const fetchDestinations = useCallback(() => {
+  const fetchDestinations = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+
     if (!originCoords) {
       setDestinations([]);
       setError("No origin airport selected");
@@ -91,6 +95,11 @@ export function useDestinations({
     setError(null);
 
     try {
+      await loadAirports();
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+
       let results: AirportWithFlightTime[];
 
       if (useTimeRange) {
@@ -103,12 +112,24 @@ export function useDestinations({
         results = getDestinationsByFlightTime(originCoords, flightTimeInSeconds);
       }
 
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+
       setDestinations(results);
       setError(null);
     } catch (err) {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+
       setError(err instanceof Error ? err.message : "Failed to fetch destinations");
       setDestinations([]);
     } finally {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+
       setIsLoading(false);
     }
   }, [originCoords, flightTimeInSeconds, useTimeRange, tolerance]);
@@ -116,27 +137,28 @@ export function useDestinations({
   // Debounced fetch
   useEffect(() => {
     // Clear existing timer
-    if (debounceTimer) {
-      clearTimeout(debounceTimer);
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
     }
 
     // Set new timer
     const timer = setTimeout(() => {
-      fetchDestinations();
+      void fetchDestinations();
     }, debounceMs);
 
-    setDebounceTimer(timer);
+    debounceTimerRef.current = timer;
 
     // Cleanup
     return () => {
-      if (timer) {
-        clearTimeout(timer);
+      if (debounceTimerRef.current === timer) {
+        debounceTimerRef.current = null;
       }
+      clearTimeout(timer);
     };
-  }, [flightTimeInSeconds, originCoords, useTimeRange, tolerance]);
+  }, [debounceMs, fetchDestinations]);
 
   const refresh = useCallback(() => {
-    fetchDestinations();
+    void fetchDestinations();
   }, [fetchDestinations]);
 
   return {

--- a/hooks/useDestinations.ts
+++ b/hooks/useDestinations.ts
@@ -10,6 +10,7 @@ import { Airport } from "@/types/airport";
 import { Coordinates } from "@/types/location";
 import { AirportWithFlightTime } from "@/types/radius";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 
 interface UseDestinationsOptions {
   /** Origin airport */
@@ -33,6 +34,114 @@ interface UseDestinationsResult {
   error: string | null;
   /** Refresh destinations */
   refresh: () => void;
+}
+
+interface DestinationStateSetters {
+  setDestinations: Dispatch<SetStateAction<AirportWithFlightTime[]>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setIsLoading: Dispatch<SetStateAction<boolean>>;
+}
+
+function getOriginCoordinates(origin: Airport | null): Coordinates | null {
+  if (!origin) return null;
+  return { lat: origin.lat, lon: origin.lon };
+}
+
+function clearDebounceTimer(
+  debounceTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>
+) {
+  if (!debounceTimerRef.current) {
+    return;
+  }
+
+  clearTimeout(debounceTimerRef.current);
+  debounceTimerRef.current = null;
+}
+
+function invalidateDestinationRequests(
+  requestIdRef: MutableRefObject<number>,
+  debounceTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>
+) {
+  requestIdRef.current += 1;
+  clearDebounceTimer(debounceTimerRef);
+}
+
+function isCurrentRequest(
+  requestIdRef: MutableRefObject<number>,
+  requestId: number
+) {
+  return requestId === requestIdRef.current;
+}
+
+function resolveDestinations(
+  originCoords: Coordinates,
+  flightTimeInSeconds: number,
+  useTimeRange: boolean,
+  tolerance?: number
+) {
+  return useTimeRange
+    ? getDestinationsInTimeRange(originCoords, flightTimeInSeconds, tolerance)
+    : getDestinationsByFlightTime(originCoords, flightTimeInSeconds);
+}
+
+async function fetchDestinations({
+  requestIdRef,
+  originCoords,
+  flightTimeInSeconds,
+  useTimeRange,
+  tolerance,
+  setDestinations,
+  setError,
+  setIsLoading,
+}: {
+  requestIdRef: MutableRefObject<number>;
+  originCoords: Coordinates | null;
+  flightTimeInSeconds: number;
+  useTimeRange: boolean;
+  tolerance?: number;
+} & DestinationStateSetters) {
+  const requestId = ++requestIdRef.current;
+
+  if (!originCoords) {
+    setDestinations([]);
+    setError("No origin airport selected");
+    setIsLoading(false);
+    return;
+  }
+
+  setIsLoading(true);
+  setError(null);
+
+  try {
+    await loadAirports();
+    if (!isCurrentRequest(requestIdRef, requestId)) {
+      return;
+    }
+
+    const results = resolveDestinations(
+      originCoords,
+      flightTimeInSeconds,
+      useTimeRange,
+      tolerance
+    );
+    if (!isCurrentRequest(requestIdRef, requestId)) {
+      return;
+    }
+
+    setDestinations(results);
+    setError(null);
+  } catch (err) {
+    if (!isCurrentRequest(requestIdRef, requestId)) {
+      return;
+    }
+
+    setError(err instanceof Error ? err.message : "Failed to fetch destinations");
+    setDestinations([]);
+  } finally {
+    if (isCurrentRequest(requestIdRef, requestId)) {
+      setIsLoading(false);
+    }
+  }
 }
 
 /**
@@ -75,109 +184,31 @@ export function useDestinations({
   const requestIdRef = useRef(0);
 
   useEffect(() => {
-    return () => {
-      requestIdRef.current += 1;
-
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
-        debounceTimerRef.current = null;
-      }
-    };
+    return () => invalidateDestinationRequests(requestIdRef, debounceTimerRef);
   }, []);
 
-  // Convert origin to coordinates
-  const originCoords: Coordinates | null = useMemo(() => {
-    if (!origin) return null;
-    return { lat: origin.lat, lon: origin.lon };
-  }, [origin]);
+  const originCoords = useMemo(() => getOriginCoordinates(origin), [origin]);
 
-  const isCurrentRequest = useCallback((requestId: number) => {
-    return requestId === requestIdRef.current;
-  }, []);
-
-  const applySuccess = useCallback(
-    (requestId: number, results: AirportWithFlightTime[]) => {
-      if (!isCurrentRequest(requestId)) {
-        return false;
-      }
-
-      setDestinations(results);
-      setError(null);
-      return true;
-    },
-    [isCurrentRequest]
-  );
-
-  const applyFailure = useCallback(
-    (requestId: number, err: unknown) => {
-      if (!isCurrentRequest(requestId)) {
-        return false;
-      }
-
-      setError(err instanceof Error ? err.message : "Failed to fetch destinations");
-      setDestinations([]);
-      return true;
-    },
-    [isCurrentRequest]
-  );
-
-  const finishRequest = useCallback(
-    (requestId: number) => {
-      if (!isCurrentRequest(requestId)) {
-        return;
-      }
-
-      setIsLoading(false);
-    },
-    [isCurrentRequest]
-  );
-
-  // Fetch destinations
-  const fetchDestinations = useCallback(async () => {
-    const requestId = ++requestIdRef.current;
-
-    if (!originCoords) {
-      setDestinations([]);
-      setError("No origin airport selected");
-      setIsLoading(false);
-      return;
-    }
-
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      await loadAirports();
-      if (!isCurrentRequest(requestId)) {
-        return;
-      }
-
-      const results = useTimeRange
-        ? getDestinationsInTimeRange(
-          originCoords,
-          flightTimeInSeconds,
-          tolerance
-        )
-        : getDestinationsByFlightTime(originCoords, flightTimeInSeconds);
-
-      applySuccess(requestId, results);
-    } catch (err) {
-      applyFailure(requestId, err);
-    } finally {
-      finishRequest(requestId);
-    }
-  }, [applyFailure, applySuccess, finishRequest, isCurrentRequest, originCoords, flightTimeInSeconds, useTimeRange, tolerance]);
+  const fetchAndStoreDestinations = useCallback(() => {
+    return fetchDestinations({
+      requestIdRef,
+      originCoords,
+      flightTimeInSeconds,
+      useTimeRange,
+      tolerance,
+      setDestinations,
+      setError,
+      setIsLoading,
+    });
+  }, [flightTimeInSeconds, originCoords, tolerance, useTimeRange]);
 
   // Debounced fetch
   useEffect(() => {
-    // Clear existing timer
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-    }
+    clearDebounceTimer(debounceTimerRef);
 
     // Set new timer
     const timer = setTimeout(() => {
-      fetchDestinations();
+      fetchAndStoreDestinations().catch(() => undefined);
     }, debounceMs);
 
     debounceTimerRef.current = timer;
@@ -189,11 +220,11 @@ export function useDestinations({
       }
       clearTimeout(timer);
     };
-  }, [debounceMs, fetchDestinations]);
+  }, [debounceMs, fetchAndStoreDestinations]);
 
   const refresh = useCallback(() => {
-    fetchDestinations();
-  }, [fetchDestinations]);
+    fetchAndStoreDestinations().catch(() => undefined);
+  }, [fetchAndStoreDestinations]);
 
   return {
     destinations,

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>'],
-  testMatch: ['**/__tests__/utils/**/*.test.ts', '**/__tests__/services/**/*.test.ts'],
-  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
+  testMatch: ['**/__tests__/utils/**/*.test.ts', '**/__tests__/services/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'node'],
   testPathIgnorePatterns: ['/node_modules/', '/.expo/'],
   collectCoverageFrom: [
     'utils/**/*.ts',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,3 @@
-/* global jest */
 /* eslint-env jest */
 /**
  * Jest setup file for Expo projects.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -16,6 +16,9 @@ jest.mock('expo-constants', () => ({
     nativeAppBuildVersion: '1',
   },
 }));
+
+// Tell React we are running tests so act() works without noisy warnings.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
  
 
 

--- a/react-test-renderer.d.ts
+++ b/react-test-renderer.d.ts
@@ -1,0 +1,5 @@
+declare module 'react-test-renderer' {
+  const TestRenderer: any;
+  export default TestRenderer;
+  export const act: any;
+}


### PR DESCRIPTION
## Summary
The Flight Setup screen now waits for the airport dataset to load before it calculates reachable destinations. This fixes the empty destination list that could appear even when the slider value updated correctly on device.

This update also includes a slider implementation refactor in `components/time-slider/TimeSlider.tsx` to keep the touch interaction stable in Expo Go while preserving the new destination-loading behavior. That runtime change is part of the fix in this branch and is called out here explicitly for review clarity.

## Root Cause
`useDestinations` was querying the radius-based destination helpers before the airport cache had been warmed. When the cache was still empty, the destination query returned no results and the UI stayed blank until a later refresh.

## Fix
- preload the airport dataset inside `useDestinations` before calculating destinations
- keep the async request flow race-safe so stale refreshes do not overwrite newer results
- invalidate in-flight work on unmount so async continuations cannot update after the hook is gone
- treat the hook as loading while the airport cache is warming so the empty state does not flash prematurely
- add regression coverage for both the hook and the Flight Setup screen
- keep the slider interaction on a stable Expo Go-friendly implementation while the destination flow is being exercised

## Validation
- `npx tsc --noEmit`
- `npm test -- --runInBand`
- `npm run lint` (passes with unrelated warnings in other files)
