### PR TITLE
feat: redesign flight setup destination selection

### DIFF
--- a/__tests__/screens/FlightSetupScreen.test.tsx
+++ b/__tests__/screens/FlightSetupScreen.test.tsx
@@ -3,7 +3,7 @@ import TestRenderer, { act } from 'react-test-renderer';
 
 import FlightSetupScreen from '@/screens/FlightSetupScreen';
 import { loadAirports } from '@/services/airportService';
-import { getDestinationsByFlightTime, getDestinationsInTimeRange } from '@/services/radiusService';
+import { getDestinationsInTimeBucket, getDestinationsInTimeRange, getFlightTimeBucket } from '@/services/radiusService';
 
 jest.mock('react-native', () => {
   type HostProps = React.PropsWithChildren<Record<string, unknown>>;
@@ -38,10 +38,14 @@ jest.mock('@/components/destinations/DestinationsList', () => ({
     destinations,
     isLoading,
     error,
+    contentBottomInset,
+    headerSubtitle,
   }: {
     destinations: Array<{ city: string }>;
     isLoading: boolean;
     error: string | null;
+    contentBottomInset?: number;
+    headerSubtitle?: string;
   }) => {
     if (isLoading) {
       return React.createElement('Text', { testID: 'destinations-state' }, 'loading');
@@ -51,9 +55,18 @@ jest.mock('@/components/destinations/DestinationsList', () => ({
     }
 
     return React.createElement(
-      'Text',
-      { testID: 'destinations-state' },
-      destinations.map((destination) => destination.city).join(',')
+      'View',
+      null,
+      React.createElement(
+        'Text',
+        { testID: 'destinations-state' },
+        destinations.map((destination) => destination.city).join(',')
+      ),
+      React.createElement(
+        'Text',
+        { testID: 'destinations-meta' },
+        `${headerSubtitle ?? ''}|${contentBottomInset ?? 0}`
+      )
     );
   },
 }));
@@ -64,7 +77,7 @@ jest.mock('@/components/time-slider/TimeSlider', () => ({
       'Pressable',
       {
         testID: 'mock-time-slider',
-        onPress: () => onValueChange(10800),
+        onPress: () => onValueChange(4200),
       },
       React.createElement('Text', null, 'Mock Slider')
     );
@@ -113,6 +126,12 @@ jest.mock('react-native-safe-area-context', () => ({
   SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => {
     return React.createElement('SafeAreaView', props, children);
   },
+  useSafeAreaInsets: () => ({
+    top: 0,
+    right: 0,
+    bottom: 20,
+    left: 0,
+  }),
 }));
 
 jest.mock('@/hooks/use-color-scheme', () => ({
@@ -163,8 +182,18 @@ jest.mock('@/services/airportService', () => ({
 }));
 
 jest.mock('@/services/radiusService', () => ({
-  getDestinationsByFlightTime: jest.fn(),
+  getDestinationsInTimeBucket: jest.fn(),
   getDestinationsInTimeRange: jest.fn(),
+  getFlightTimeBucket: jest.fn((timeInSeconds: number) => {
+    if (timeInSeconds <= 1800) {
+      return { minTimeInSeconds: 0, maxTimeInSeconds: 1800 };
+    }
+
+    return {
+      minTimeInSeconds: timeInSeconds - 600,
+      maxTimeInSeconds: timeInSeconds,
+    };
+  }),
 }));
 
 const mockDestinations = [
@@ -210,8 +239,18 @@ describe('FlightSetupScreen', () => {
     jest.clearAllMocks();
     (loadAirports as jest.Mock).mockImplementation(() => Promise.resolve());
     (getDestinationsInTimeRange as jest.Mock).mockReturnValue([]);
-    (getDestinationsByFlightTime as jest.Mock).mockImplementation((_origin, flightTime) => {
-      return flightTime >= 10800 ? mockDestinations : mockDestinations.slice(0, 1);
+    (getFlightTimeBucket as jest.Mock).mockImplementation((timeInSeconds: number) => {
+      if (timeInSeconds <= 1800) {
+        return { minTimeInSeconds: 0, maxTimeInSeconds: 1800 };
+      }
+
+      return {
+        minTimeInSeconds: timeInSeconds - 600,
+        maxTimeInSeconds: timeInSeconds,
+      };
+    });
+    (getDestinationsInTimeBucket as jest.Mock).mockImplementation((_origin, flightTime) => {
+      return flightTime >= 4200 ? mockDestinations : mockDestinations.slice(0, 1);
     });
   });
 
@@ -239,6 +278,7 @@ describe('FlightSetupScreen', () => {
     }
 
     expect(getText(renderer, 'destinations-state')).toBe('Norman');
+    expect(getText(renderer, 'destinations-meta')).toContain('50m - 1h 0m');
 
     act(() => {
       renderer.root.findByProps({ testID: 'mock-time-slider' }).props.onPress();
@@ -257,9 +297,13 @@ describe('FlightSetupScreen', () => {
     }
 
     expect(getText(renderer, 'destinations-state')).toBe('Norman,Stillwater');
-    expect(getDestinationsByFlightTime).toHaveBeenCalledWith(
+    expect(getText(renderer, 'destinations-meta')).toContain('1h 0m - 1h 10m');
+    expect(getText(renderer, 'destinations-meta')).toContain('|146');
+    expect(getDestinationsInTimeBucket).toHaveBeenCalledWith(
       { lat: 35.3931, lon: -97.6007 },
-      10800
+      4200,
+      600,
+      1800
     );
   });
 });

--- a/__tests__/screens/FlightSetupScreen.test.tsx
+++ b/__tests__/screens/FlightSetupScreen.test.tsx
@@ -184,7 +184,7 @@ jest.mock('@/services/airportService', () => ({
 jest.mock('@/services/radiusService', () => ({
   getDestinationsInTimeBucket: jest.fn(),
   getDestinationsInTimeRange: jest.fn(),
-  getFlightTimeBucket: jest.fn((timeInSeconds: number) => {
+  getFlightTimeBucket: jest.fn(({ timeInSeconds }: { timeInSeconds: number }) => {
     if (timeInSeconds <= 1800) {
       return { minTimeInSeconds: 0, maxTimeInSeconds: 1800 };
     }
@@ -239,7 +239,7 @@ describe('FlightSetupScreen', () => {
     jest.clearAllMocks();
     (loadAirports as jest.Mock).mockImplementation(() => Promise.resolve());
     (getDestinationsInTimeRange as jest.Mock).mockReturnValue([]);
-    (getFlightTimeBucket as jest.Mock).mockImplementation((timeInSeconds: number) => {
+    (getFlightTimeBucket as jest.Mock).mockImplementation(({ timeInSeconds }: { timeInSeconds: number }) => {
       if (timeInSeconds <= 1800) {
         return { minTimeInSeconds: 0, maxTimeInSeconds: 1800 };
       }
@@ -249,9 +249,11 @@ describe('FlightSetupScreen', () => {
         maxTimeInSeconds: timeInSeconds,
       };
     });
-    (getDestinationsInTimeBucket as jest.Mock).mockImplementation((_origin, flightTime) => {
-      return flightTime >= 4200 ? mockDestinations : mockDestinations.slice(0, 1);
-    });
+    (getDestinationsInTimeBucket as jest.Mock).mockImplementation(
+      ({ timeInSeconds }: { timeInSeconds: number }) => {
+        return timeInSeconds >= 4200 ? mockDestinations : mockDestinations.slice(0, 1);
+      }
+    );
   });
 
   afterEach(() => {
@@ -298,12 +300,12 @@ describe('FlightSetupScreen', () => {
 
     expect(getText(renderer, 'destinations-state')).toBe('Norman,Stillwater');
     expect(getText(renderer, 'destinations-meta')).toContain('1h 0m - 1h 10m');
-    expect(getText(renderer, 'destinations-meta')).toContain('|146');
-    expect(getDestinationsInTimeBucket).toHaveBeenCalledWith(
-      { lat: 35.3931, lon: -97.6007 },
-      4200,
-      600,
-      1800
-    );
+    expect(getText(renderer, 'destinations-meta')).toContain('|32');
+    expect(getDestinationsInTimeBucket).toHaveBeenCalledWith({
+      origin: { lat: 35.3931, lon: -97.6007 },
+      timeInSeconds: 4200,
+      bucketSizeInSeconds: 600,
+      initialBucketMaxTime: 1800,
+    });
   });
 });

--- a/__tests__/services/radiusService.test.ts
+++ b/__tests__/services/radiusService.test.ts
@@ -104,80 +104,80 @@ describe("radiusService", () => {
 
   describe("calculateMaxDistance", () => {
     it("should calculate distance for 1 hour flight", () => {
-      const distance = calculateMaxDistance(3600); // 1 hour
+      const distance = calculateMaxDistance({ timeInSeconds: 3600 }); // 1 hour
       // 3600s - 1500s overhead = 2100s = 0.583h
       // 0.583h * 450mph = 262.5 miles
       expect(distance).toBeCloseTo(262.5, 1);
     });
 
     it("should calculate distance for 2 hour flight", () => {
-      const distance = calculateMaxDistance(7200); // 2 hours
+      const distance = calculateMaxDistance({ timeInSeconds: 7200 }); // 2 hours
       // 7200s - 1500s = 5700s = 1.583h
       // 1.583h * 450mph = 712.5 miles
       expect(distance).toBeCloseTo(712.5, 1);
     });
 
     it("should calculate distance for 5 hour flight", () => {
-      const distance = calculateMaxDistance(18000); // 5 hours
+      const distance = calculateMaxDistance({ timeInSeconds: 18000 }); // 5 hours
       // 18000s - 1500s = 16500s = 4.583h
       // 4.583h * 450mph = 2062.5 miles
       expect(distance).toBeCloseTo(2062.5, 1);
     });
 
     it("should handle 30 minute flight", () => {
-      const distance = calculateMaxDistance(1800); // 30 minutes
+      const distance = calculateMaxDistance({ timeInSeconds: 1800 }); // 30 minutes
       // 1800s - 1500s = 300s = 0.083h
       // 0.083h * 450mph = 37.5 miles
       expect(distance).toBeCloseTo(37.5, 1);
     });
 
     it("should return 0 for very short flights (less than overhead)", () => {
-      const distance = calculateMaxDistance(1000); // Less than 25 min overhead
+      const distance = calculateMaxDistance({ timeInSeconds: 1000 }); // Less than 25 min overhead
       expect(distance).toBe(0);
     });
 
     it("should handle negative time input", () => {
-      const distance = calculateMaxDistance(-100);
+      const distance = calculateMaxDistance({ timeInSeconds: -100 });
       expect(distance).toBe(0);
     });
   });
 
   describe("estimateFlightTime", () => {
     it("should estimate time for ~190 mile flight", () => {
-      const time = estimateFlightTime(190); // Boston from NYC
+      const time = estimateFlightTime({ distanceInMiles: 190 }); // Boston from NYC
       // 190 miles / 450mph = 0.422h = 1520s
       // Add 1500s overhead = 3020s (~50 minutes)
       expect(time).toBeCloseTo(3020, 0);
     });
 
     it("should estimate time for ~250 mile flight", () => {
-      const time = estimateFlightTime(250);
+      const time = estimateFlightTime({ distanceInMiles: 250 });
       // 250 / 450 = 0.556h = 2000s
       // Add 1500s = 3500s (~58 minutes)
       expect(time).toBeCloseTo(3500, 0);
     });
 
     it("should estimate time for ~2450 mile flight", () => {
-      const time = estimateFlightTime(2450); // LA from NYC
+      const time = estimateFlightTime({ distanceInMiles: 2450 }); // LA from NYC
       // 2450 / 450 = 5.444h = 19600s
       // Add 1500s = 21100s (~5.86 hours)
       expect(time).toBeCloseTo(21100, 0);
     });
 
     it("should handle zero distance", () => {
-      const time = estimateFlightTime(0);
+      const time = estimateFlightTime({ distanceInMiles: 0 });
       expect(time).toBe(FLIGHT_CONSTANTS.OVERHEAD_SECONDS);
     });
 
     it("should return integer seconds", () => {
-      const time = estimateFlightTime(123.456);
+      const time = estimateFlightTime({ distanceInMiles: 123.456 });
       expect(Number.isInteger(time)).toBe(true);
     });
   });
 
   describe("getFlightEstimate", () => {
     it("should return complete flight estimate", () => {
-      const estimate = getFlightEstimate(3600);
+      const estimate = getFlightEstimate({ timeInSeconds: 3600 });
 
       expect(estimate.timeInSeconds).toBe(3600);
       expect(estimate.distanceInMiles).toBeCloseTo(262.5, 1);
@@ -194,7 +194,7 @@ describe("radiusService", () => {
       // Boston at 190 miles with flight time ~3020s (50 min) is within distance
       // but outside the tolerance window (3420s-3780s for 1 hour ±5%)
       // So we test with a longer time where Boston would be included
-      const destinations = getDestinationsInTimeRange(jfk, 3600);
+      const destinations = getDestinationsInTimeRange({ origin: jfk, timeInSeconds: 3600 });
 
       // With current mock setup and tolerance, results depend on exact timing
       // Just verify the structure is correct
@@ -206,14 +206,14 @@ describe("radiusService", () => {
 
     it("should respect tolerance parameter", () => {
       // With very low tolerance, fewer airports should match
-      const strictResults = getDestinationsInTimeRange(jfk, 3600, 0.01);
-      const lenientResults = getDestinationsInTimeRange(jfk, 3600, 0.2);
+      const strictResults = getDestinationsInTimeRange({ origin: jfk, timeInSeconds: 3600, tolerance: 0.01 });
+      const lenientResults = getDestinationsInTimeRange({ origin: jfk, timeInSeconds: 3600, tolerance: 0.2 });
 
       expect(lenientResults.length).toBeGreaterThanOrEqual(strictResults.length);
     });
 
     it("should sort results by distance", () => {
-      const destinations = getDestinationsInTimeRange(jfk, 18000);
+      const destinations = getDestinationsInTimeRange({ origin: jfk, timeInSeconds: 18000 });
 
       for (let i = 0; i < destinations.length - 1; i++) {
         expect(destinations[i].distance).toBeLessThanOrEqual(
@@ -223,13 +223,13 @@ describe("radiusService", () => {
     });
 
     it("should return empty array for very short time with no nearby airports", () => {
-      const destinations = getDestinationsInTimeRange(jfk, 1800); // 30 min
+      const destinations = getDestinationsInTimeRange({ origin: jfk, timeInSeconds: 1800 }); // 30 min
       // With 30min = 37.5 miles max, and overhead, no airports should match
       expect(destinations.length).toBe(0);
     });
 
     it("should include flight time and distance for each airport", () => {
-      const destinations = getDestinationsInTimeRange(jfk, 7200);
+      const destinations = getDestinationsInTimeRange({ origin: jfk, timeInSeconds: 7200 });
 
       destinations.forEach((airport) => {
         expect(airport.distance).toBeDefined();
@@ -244,7 +244,7 @@ describe("radiusService", () => {
     const jfk = { lat: 40.6413, lon: -73.7781 };
 
     it("should find all airports within max flight time", () => {
-      const destinations = getDestinationsByFlightTime(jfk, 3600);
+      const destinations = getDestinationsByFlightTime({ origin: jfk, maxFlightTime: 3600 });
 
       // 1 hour = ~262.5 mile radius
       // Boston at 190 miles with ~50min flight time should be included
@@ -258,8 +258,8 @@ describe("radiusService", () => {
     });
 
     it("should include more airports than time range filter", () => {
-      const timeRange = getDestinationsInTimeRange(jfk, 7200);
-      const maxTime = getDestinationsByFlightTime(jfk, 7200);
+      const timeRange = getDestinationsInTimeRange({ origin: jfk, timeInSeconds: 7200 });
+      const maxTime = getDestinationsByFlightTime({ origin: jfk, maxFlightTime: 7200 });
 
       // getDestinationsByFlightTime should include all airports UP TO the time
       // while getDestinationsInTimeRange filters to a tolerance window
@@ -268,7 +268,7 @@ describe("radiusService", () => {
     });
 
     it("should sort results by distance", () => {
-      const destinations = getDestinationsByFlightTime(jfk, 18000);
+      const destinations = getDestinationsByFlightTime({ origin: jfk, maxFlightTime: 18000 });
 
       for (let i = 0; i < destinations.length - 1; i++) {
         expect(destinations[i].distance).toBeLessThanOrEqual(
@@ -278,7 +278,7 @@ describe("radiusService", () => {
     });
 
     it("should include flight time and distance metadata", () => {
-      const destinations = getDestinationsByFlightTime(jfk, 10800);
+      const destinations = getDestinationsByFlightTime({ origin: jfk, maxFlightTime: 10800 });
 
       destinations.forEach((airport) => {
         expect(airport.distance).toBeDefined();
@@ -291,14 +291,14 @@ describe("radiusService", () => {
 
   describe("getFlightTimeBucket", () => {
     it("uses the full 30 minute range for the first bucket", () => {
-      expect(getFlightTimeBucket(1800)).toEqual({
+      expect(getFlightTimeBucket({ timeInSeconds: 1800 })).toEqual({
         minTimeInSeconds: 0,
         maxTimeInSeconds: 1800,
       });
     });
 
     it("uses the previous 10 minute step for later buckets", () => {
-      expect(getFlightTimeBucket(4200)).toEqual({
+      expect(getFlightTimeBucket({ timeInSeconds: 4200 })).toEqual({
         minTimeInSeconds: 3600,
         maxTimeInSeconds: 4200,
       });
@@ -387,12 +387,12 @@ describe("radiusService", () => {
     const jfk = { lat: 40.6413, lon: -73.7781 };
 
     it("treats the first bucket as up to 30 minutes", () => {
-      const destinations = getDestinationsInTimeBucket(jfk, 1800);
+      const destinations = getDestinationsInTimeBucket({ origin: jfk, timeInSeconds: 1800 });
       expect(destinations).toEqual([]);
     });
 
     it("returns only airports inside the selected 10 minute window", () => {
-      const destinations = getDestinationsInTimeBucket(jfk, 3600);
+      const destinations = getDestinationsInTimeBucket({ origin: jfk, timeInSeconds: 3600 });
 
       expect(destinations.map((airport) => airport.icao)).toEqual(["KBOS"]);
       expect(destinations[0].flightTime).toBeGreaterThan(3000);
@@ -403,7 +403,7 @@ describe("radiusService", () => {
   describe("realistic flight scenarios", () => {
     it("should estimate NYC to Boston correctly", () => {
       const distance = 190; // miles
-      const time = estimateFlightTime(distance);
+      const time = estimateFlightTime({ distanceInMiles: distance });
 
       // Real-world flight time is roughly 1 hour
       expect(time).toBeGreaterThan(2700); // >45 min
@@ -412,7 +412,7 @@ describe("radiusService", () => {
 
     it("should estimate NYC to LA correctly", () => {
       const distance = 2450; // miles
-      const time = estimateFlightTime(distance);
+      const time = estimateFlightTime({ distanceInMiles: distance });
 
       // Real-world flight time is roughly 5.5-6 hours
       expect(time).toBeGreaterThan(18000); // >5 hours
@@ -420,7 +420,7 @@ describe("radiusService", () => {
     });
 
     it("should handle coast-to-coast range with 5 hour budget", () => {
-      const maxDistance = calculateMaxDistance(18000); // 5 hours
+      const maxDistance = calculateMaxDistance({ timeInSeconds: 18000 }); // 5 hours
 
       // Should be able to reach about 2000 miles
       expect(maxDistance).toBeGreaterThan(1800);

--- a/__tests__/services/radiusService.test.ts
+++ b/__tests__/services/radiusService.test.ts
@@ -7,10 +7,14 @@ import {
     estimateFlightTime,
     FLIGHT_CONSTANTS,
     getDestinationsByFlightTime,
+    getDestinationsInTimeBucket,
     getDestinationsInTimeRange,
+    getFlightTimeBucket,
     getFlightEstimate,
+    prioritizeDestinations,
 } from "@/services/radiusService";
 import { Coordinates } from "@/types/location";
+import { AirportWithFlightTime } from "@/types/radius";
 
 // Mock the airportService
 jest.mock("@/services/airportService", () => ({
@@ -72,6 +76,24 @@ jest.mock("@/utils/distance", () => ({
 }));
 
 describe("radiusService", () => {
+  const buildAirportWithFlightTime = (
+    overrides: Partial<AirportWithFlightTime>
+  ): AirportWithFlightTime => ({
+    icao: "KTEST",
+    iata: "TST",
+    name: "Test Airport",
+    city: "Test City",
+    country: "US",
+    state: "OK",
+    lat: 35,
+    lon: -97,
+    elevation: 1000,
+    tz: "America/Chicago",
+    distance: 100,
+    flightTime: 3600,
+    ...overrides,
+  });
+
   describe("FLIGHT_CONSTANTS", () => {
     it("should have correct constant values", () => {
       expect(FLIGHT_CONSTANTS.CRUISE_SPEED_MPH).toBe(450);
@@ -264,6 +286,117 @@ describe("radiusService", () => {
         expect(airport.distance).toBeGreaterThan(0);
         expect(airport.flightTime).toBeGreaterThan(0);
       });
+    });
+  });
+
+  describe("getFlightTimeBucket", () => {
+    it("uses the full 30 minute range for the first bucket", () => {
+      expect(getFlightTimeBucket(1800)).toEqual({
+        minTimeInSeconds: 0,
+        maxTimeInSeconds: 1800,
+      });
+    });
+
+    it("uses the previous 10 minute step for later buckets", () => {
+      expect(getFlightTimeBucket(4200)).toEqual({
+        minTimeInSeconds: 3600,
+        maxTimeInSeconds: 4200,
+      });
+    });
+  });
+
+  describe("prioritizeDestinations", () => {
+    it("prioritizes major airport keywords before smaller fields", () => {
+      const prioritized = prioritizeDestinations([
+        buildAirportWithFlightTime({
+          icao: "KREG",
+          iata: "REG",
+          name: "Prairie Regional Airport",
+          city: "Prairie",
+          distance: 200,
+          flightTime: 3900,
+        }),
+        buildAirportWithFlightTime({
+          icao: "KINT",
+          iata: "INT",
+          name: "Metro International Airport",
+          city: "Metro",
+          distance: 240,
+          flightTime: 4000,
+        }),
+        buildAirportWithFlightTime({
+          icao: "KWLD",
+          iata: "WLD",
+          name: "Global World Airport",
+          city: "Global",
+          distance: 210,
+          flightTime: 4010,
+        }),
+        buildAirportWithFlightTime({
+          icao: "KNAT",
+          iata: "NAT",
+          name: "Capital National Airport",
+          city: "Capital",
+          distance: 180,
+          flightTime: 3950,
+        }),
+        buildAirportWithFlightTime({
+          icao: "KLOC",
+          iata: "",
+          name: "Odom's Roost Airport",
+          city: "Odom",
+          distance: 120,
+          flightTime: 3850,
+        }),
+      ]);
+
+      expect(prioritized.map((airport) => airport.icao)).toEqual([
+        "KWLD",
+        "KINT",
+        "KNAT",
+        "KREG",
+        "KLOC",
+      ]);
+    });
+
+    it("uses distance to break ties inside the same priority level", () => {
+      const prioritized = prioritizeDestinations([
+        buildAirportWithFlightTime({
+          icao: "KINT",
+          iata: "INT",
+          name: "Metro International Airport",
+          city: "Metro",
+          distance: 240,
+          flightTime: 4000,
+        }),
+        buildAirportWithFlightTime({
+          icao: "KWLD",
+          iata: "WLD",
+          name: "Global World Airport",
+          city: "Global",
+          distance: 210,
+          flightTime: 4010,
+        }),
+      ]);
+
+      expect(prioritized.map((airport) => airport.icao)).toEqual(["KWLD", "KINT"]);
+    });
+  });
+
+  describe("getDestinationsInTimeBucket", () => {
+    const jfk = { lat: 40.6413, lon: -73.7781 };
+
+    it("treats the first bucket as up to 30 minutes", () => {
+      const destinations = getDestinationsInTimeBucket(jfk, 1800);
+      expect(destinations).toEqual([]);
+    });
+
+    it("returns only airports inside the selected 10 minute window", () => {
+      const destinations = getDestinationsInTimeBucket(jfk, 3600);
+
+      expect(destinations.map((airport) => airport.icao)).toEqual(["KBOS"]);
+      expect(destinations[0].flightTime).toBeGreaterThan(3000);
+      expect(destinations[0].flightTime).toBeLessThanOrEqual(3600);
     });
   });
 

--- a/__tests__/services/useDestinations.test.ts
+++ b/__tests__/services/useDestinations.test.ts
@@ -161,10 +161,10 @@ describe('useDestinations', () => {
     });
 
     expect(getDestinationsByFlightTime).toHaveBeenCalledTimes(1);
-    expect(getDestinationsByFlightTime).toHaveBeenCalledWith(
-      { lat: mockOrigin.lat, lon: mockOrigin.lon },
-      7200
-    );
+    expect(getDestinationsByFlightTime).toHaveBeenCalledWith({
+      origin: { lat: mockOrigin.lat, lon: mockOrigin.lon },
+      maxFlightTime: 7200,
+    });
     expect(hook.current.destinations).toEqual(mockDestinations);
     expect(hook.current.isLoading).toBe(false);
 
@@ -222,12 +222,12 @@ describe('useDestinations', () => {
       await Promise.resolve();
     });
 
-    expect(getDestinationsInTimeBucket).toHaveBeenCalledWith(
-      { lat: mockOrigin.lat, lon: mockOrigin.lon },
-      4200,
-      600,
-      1800
-    );
+    expect(getDestinationsInTimeBucket).toHaveBeenCalledWith({
+      origin: { lat: mockOrigin.lat, lon: mockOrigin.lon },
+      timeInSeconds: 4200,
+      bucketSizeInSeconds: 600,
+      initialBucketMaxTime: 1800,
+    });
     expect(hook.current.destinations).toEqual(mockDestinations);
     hook.unmount();
   });

--- a/__tests__/services/useDestinations.test.ts
+++ b/__tests__/services/useDestinations.test.ts
@@ -3,7 +3,11 @@ import TestRenderer, { act } from 'react-test-renderer';
 
 import { useDestinations } from '@/hooks/useDestinations';
 import { loadAirports } from '@/services/airportService';
-import { getDestinationsByFlightTime, getDestinationsInTimeRange } from '@/services/radiusService';
+import {
+  getDestinationsByFlightTime,
+  getDestinationsInTimeBucket,
+  getDestinationsInTimeRange,
+} from '@/services/radiusService';
 import type { Airport } from '@/types/airport';
 import type { AirportWithFlightTime } from '@/types/radius';
 
@@ -13,6 +17,7 @@ jest.mock('@/services/airportService', () => ({
 
 jest.mock('@/services/radiusService', () => ({
   getDestinationsByFlightTime: jest.fn(),
+  getDestinationsInTimeBucket: jest.fn(),
   getDestinationsInTimeRange: jest.fn(),
 }));
 
@@ -53,6 +58,8 @@ function renderUseDestinations({
   origin,
   flightTimeInSeconds,
   useTimeRange,
+  bucketIntervalSeconds,
+  initialBucketMaxTime,
   debounceMs,
 }: UseDestinationsProps) {
   let latestResult: ReturnType<typeof useDestinations> | null = null;
@@ -69,6 +76,8 @@ function renderUseDestinations({
         origin,
         flightTimeInSeconds,
         useTimeRange,
+        bucketIntervalSeconds,
+        initialBucketMaxTime,
         debounceMs,
       })
     );
@@ -108,6 +117,7 @@ describe('useDestinations', () => {
     jest.clearAllMocks();
     (loadAirports as jest.Mock).mockImplementation(() => Promise.resolve());
     (getDestinationsByFlightTime as jest.Mock).mockReturnValue(mockDestinations);
+    (getDestinationsInTimeBucket as jest.Mock).mockReturnValue(mockDestinations);
     (getDestinationsInTimeRange as jest.Mock).mockReturnValue([]);
   });
 
@@ -192,5 +202,33 @@ describe('useDestinations', () => {
     });
 
     expect(getDestinationsByFlightTime).not.toHaveBeenCalled();
+  });
+
+  it('uses the bucketed lookup when a bucket interval is provided', async () => {
+    const hook = renderUseDestinations({
+      origin: mockOrigin,
+      flightTimeInSeconds: 4200,
+      useTimeRange: false,
+      bucketIntervalSeconds: 600,
+      initialBucketMaxTime: 1800,
+      debounceMs: 5,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getDestinationsInTimeBucket).toHaveBeenCalledWith(
+      { lat: mockOrigin.lat, lon: mockOrigin.lon },
+      4200,
+      600,
+      1800
+    );
+    expect(hook.current.destinations).toEqual(mockDestinations);
+    hook.unmount();
   });
 });

--- a/components/destinations/DestinationCard.tsx
+++ b/components/destinations/DestinationCard.tsx
@@ -9,7 +9,7 @@ import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { Colors, Spacing, Typography } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
-import { AirportWithFlightTime } from "@/types/radius";
+import type { AirportWithFlightTime } from "@/types/radius";
 import { formatTimeValue } from "@/utils/timeSlider";
 import { impactAsync, ImpactFeedbackStyle } from "expo-haptics";
 import { StyleSheet, TouchableOpacity, View } from "react-native";
@@ -129,6 +129,7 @@ export function DestinationCard({
 
   const { formatted: flightTimeFormatted } = formatTimeValue(airport.flightTime);
   const distanceFormatted = `${Math.round(airport.distance)} mi`;
+  const cardBorderColor = isSelected ? colors.tint : colors.border;
 
   const handlePress = () => {
     impactAsync(ImpactFeedbackStyle.Medium).catch(() => {
@@ -145,62 +146,129 @@ export function DestinationCard({
           compact && styles.compactCard,
           {
             backgroundColor: colors.cardBackground,
-            borderColor: isSelected ? colors.tint : colors.border,
+            borderColor: cardBorderColor,
           },
         ]}
       >
-        <View style={styles.header}>
-          <View style={styles.nameContainer}>
-            <ThemedText style={[styles.airportName, compact && styles.compactAirportName]}>
-              {airport.name}
-            </ThemedText>
-            <ThemedText
-              style={[
-                styles.cityCountry,
-                compact && styles.compactCityCountry,
-                { color: colors.textSecondary },
-              ]}
-            >
-              {airport.city}, {airport.country}
-            </ThemedText>
-          </View>
-          <View style={styles.codes}>
-            <ThemedText style={[styles.codeText, { color: colors.textSecondary }]}>
-              {airport.icao}
-            </ThemedText>
-            {airport.iata && (
-              <ThemedText style={[styles.codeText, { color: colors.textSecondary }]}>
-                {airport.iata}
-              </ThemedText>
-            )}
-          </View>
-        </View>
-
-        <View
-          style={[
-            styles.metadata,
-            compact && styles.compactMetadata,
-            { borderTopColor: colors.border },
-          ]}
-        >
-          <View style={styles.metadataItem}>
-            <ThemedText style={[styles.metadataLabel, { color: colors.textSecondary }]}>
-              Flight Time
-            </ThemedText>
-            <ThemedText style={[styles.metadataValue, compact && styles.compactMetadataValue]}>
-              {flightTimeFormatted}
-            </ThemedText>
-          </View>
-          <View style={styles.metadataItem}>
-            <ThemedText style={[styles.metadataLabel, { color: colors.textSecondary }]}>
-              Distance
-            </ThemedText>
-            <ThemedText style={[styles.metadataValue, compact && styles.compactMetadataValue]}>
-              {distanceFormatted}
-            </ThemedText>
-          </View>
-        </View>
+        <DestinationHeader airport={airport} compact={compact} textSecondary={colors.textSecondary} />
+        <DestinationMetadata
+          compact={compact}
+          textSecondary={colors.textSecondary}
+          borderColor={colors.border}
+          flightTimeFormatted={flightTimeFormatted}
+          distanceFormatted={distanceFormatted}
+        />
       </ThemedView>
     </TouchableOpacity>
+  );
+}
+
+function DestinationHeader({
+  airport,
+  compact,
+  textSecondary,
+}: {
+  airport: AirportWithFlightTime;
+  compact: boolean;
+  textSecondary: string;
+}) {
+  return (
+    <View style={styles.header}>
+      <View style={styles.nameContainer}>
+        <ThemedText style={[styles.airportName, compact && styles.compactAirportName]}>
+          {airport.name}
+        </ThemedText>
+        <ThemedText
+          style={[
+            styles.cityCountry,
+            compact && styles.compactCityCountry,
+            { color: textSecondary },
+          ]}
+        >
+          {airport.city}, {airport.country}
+        </ThemedText>
+      </View>
+      <DestinationCodes airport={airport} textSecondary={textSecondary} />
+    </View>
+  );
+}
+
+function DestinationCodes({
+  airport,
+  textSecondary,
+}: {
+  airport: AirportWithFlightTime;
+  textSecondary: string;
+}) {
+  const codeColor = { color: textSecondary };
+  const iataCode = airport.iata ? (
+    <ThemedText style={[styles.codeText, codeColor]}>{airport.iata}</ThemedText>
+  ) : null;
+
+  return (
+    <View style={styles.codes}>
+      <ThemedText style={[styles.codeText, codeColor]}>{airport.icao}</ThemedText>
+      {iataCode}
+    </View>
+  );
+}
+
+function DestinationMetadata({
+  compact,
+  textSecondary,
+  borderColor,
+  flightTimeFormatted,
+  distanceFormatted,
+}: {
+  compact: boolean;
+  textSecondary: string;
+  borderColor: string;
+  flightTimeFormatted: string;
+  distanceFormatted: string;
+}) {
+  return (
+    <View
+      style={[
+        styles.metadata,
+        compact && styles.compactMetadata,
+        { borderTopColor: borderColor },
+      ]}
+    >
+      <MetadataItem
+        label="Flight Time"
+        value={flightTimeFormatted}
+        compact={compact}
+        textSecondary={textSecondary}
+      />
+      <MetadataItem
+        label="Distance"
+        value={distanceFormatted}
+        compact={compact}
+        textSecondary={textSecondary}
+      />
+    </View>
+  );
+}
+
+function MetadataItem({
+  label,
+  value,
+  compact,
+  textSecondary,
+}: {
+  label: string;
+  value: string;
+  compact: boolean;
+  textSecondary: string;
+}) {
+  return (
+    <View style={styles.metadataItem}>
+      <ThemedText style={[styles.metadataLabel, { color: textSecondary }]}>
+        {label}
+      </ThemedText>
+      <ThemedText style={[styles.metadataValue, compact && styles.compactMetadataValue]}>
+        {value}
+      </ThemedText>
+    </View>
   );
 }

--- a/components/destinations/DestinationCard.tsx
+++ b/components/destinations/DestinationCard.tsx
@@ -21,15 +21,21 @@ interface DestinationCardProps {
   onSelect: (airport: AirportWithFlightTime) => void;
   /** Whether this destination is currently selected */
   isSelected?: boolean;
+  /** Whether to render the denser flight setup presentation */
+  compact?: boolean;
 }
 
 const styles = StyleSheet.create({
   card: {
-    padding: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm + 2,
     borderRadius: 12,
-    marginHorizontal: Spacing.md,
-    marginVertical: Spacing.sm,
-    borderWidth: 2,
+    marginVertical: Spacing.xs,
+    borderWidth: 1.5,
+  },
+  compactCard: {
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
   },
   header: {
     flexDirection: "row",
@@ -46,9 +52,15 @@ const styles = StyleSheet.create({
     fontWeight: Typography.fontWeight.semibold,
     marginBottom: 2,
   },
+  compactAirportName: {
+    fontSize: Typography.fontSize.sm,
+  },
   cityCountry: {
     fontSize: Typography.fontSize.sm,
     opacity: 0.7,
+  },
+  compactCityCountry: {
+    fontSize: Typography.fontSize.xs,
   },
   codes: {
     alignItems: "flex-end",
@@ -65,6 +77,10 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.sm,
     borderTopWidth: 1,
   },
+  compactMetadata: {
+    marginTop: Spacing.xs,
+    paddingTop: Spacing.xs,
+  },
   metadataItem: {
     flex: 1,
   },
@@ -78,6 +94,9 @@ const styles = StyleSheet.create({
   metadataValue: {
     fontSize: Typography.fontSize.sm,
     fontWeight: Typography.fontWeight.semibold,
+  },
+  compactMetadataValue: {
+    fontSize: Typography.fontSize.xs,
   },
 });
 
@@ -103,6 +122,7 @@ export function DestinationCard({
   airport,
   onSelect,
   isSelected = false,
+  compact = false,
 }: DestinationCardProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? "light"];
@@ -122,6 +142,7 @@ export function DestinationCard({
       <ThemedView
         style={[
           styles.card,
+          compact && styles.compactCard,
           {
             backgroundColor: colors.cardBackground,
             borderColor: isSelected ? colors.tint : colors.border,
@@ -130,8 +151,16 @@ export function DestinationCard({
       >
         <View style={styles.header}>
           <View style={styles.nameContainer}>
-            <ThemedText style={styles.airportName}>{airport.name}</ThemedText>
-            <ThemedText style={[styles.cityCountry, { color: colors.textSecondary }]}>
+            <ThemedText style={[styles.airportName, compact && styles.compactAirportName]}>
+              {airport.name}
+            </ThemedText>
+            <ThemedText
+              style={[
+                styles.cityCountry,
+                compact && styles.compactCityCountry,
+                { color: colors.textSecondary },
+              ]}
+            >
               {airport.city}, {airport.country}
             </ThemedText>
           </View>
@@ -148,19 +177,27 @@ export function DestinationCard({
         </View>
 
         <View
-          style={[styles.metadata, { borderTopColor: colors.border }]}
+          style={[
+            styles.metadata,
+            compact && styles.compactMetadata,
+            { borderTopColor: colors.border },
+          ]}
         >
           <View style={styles.metadataItem}>
             <ThemedText style={[styles.metadataLabel, { color: colors.textSecondary }]}>
               Flight Time
             </ThemedText>
-            <ThemedText style={styles.metadataValue}>{flightTimeFormatted}</ThemedText>
+            <ThemedText style={[styles.metadataValue, compact && styles.compactMetadataValue]}>
+              {flightTimeFormatted}
+            </ThemedText>
           </View>
           <View style={styles.metadataItem}>
             <ThemedText style={[styles.metadataLabel, { color: colors.textSecondary }]}>
               Distance
             </ThemedText>
-            <ThemedText style={styles.metadataValue}>{distanceFormatted}</ThemedText>
+            <ThemedText style={[styles.metadataValue, compact && styles.compactMetadataValue]}>
+              {distanceFormatted}
+            </ThemedText>
           </View>
         </View>
       </ThemedView>

--- a/components/destinations/DestinationsList.tsx
+++ b/components/destinations/DestinationsList.tsx
@@ -25,6 +25,14 @@ interface DestinationsListProps {
   isLoading?: boolean;
   /** Error message if data loading failed */
   error?: string | null;
+  /** Whether the cards should use the denser Flight Setup layout */
+  compactCards?: boolean;
+  /** Extra bottom space reserved for overlapping UI like a pinned footer */
+  contentBottomInset?: number;
+  /** Optional summary text for the current destination window */
+  headerSubtitle?: string;
+  /** Test identifier */
+  testID?: string;
 }
 
 const styles = StyleSheet.create({
@@ -32,17 +40,28 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   listContent: {
-    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+    paddingTop: Spacing.sm,
   },
   header: {
     paddingHorizontal: Spacing.md,
     paddingVertical: Spacing.sm,
     borderBottomWidth: 1,
   },
+  headerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: Spacing.sm,
+  },
   headerText: {
     fontSize: Typography.fontSize.sm,
     fontWeight: Typography.fontWeight.medium,
     textTransform: "uppercase",
+    opacity: 0.7,
+  },
+  headerSubtext: {
+    fontSize: Typography.fontSize.xs,
     opacity: 0.7,
   },
   emptyContainer: {
@@ -116,6 +135,10 @@ export function DestinationsList({
   onSelectDestination,
   isLoading = false,
   error = null,
+  compactCards = false,
+  contentBottomInset = 0,
+  headerSubtitle,
+  testID,
 }: DestinationsListProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? "light"];
@@ -164,12 +187,20 @@ export function DestinationsList({
   return (
     <ThemedView style={styles.container}>
       <View style={[styles.header, { borderBottomColor: colors.border }]}>
-        <ThemedText style={[styles.headerText, { color: colors.textSecondary }]}>
-          {destinations.length} Available Destination{destinations.length !== 1 ? "s" : ""}
-        </ThemedText>
+        <View style={styles.headerRow}>
+          <ThemedText style={[styles.headerText, { color: colors.textSecondary }]}>
+            {destinations.length} Destination{destinations.length !== 1 ? "s" : ""}
+          </ThemedText>
+          {headerSubtitle ? (
+            <ThemedText style={[styles.headerSubtext, { color: colors.textSecondary }]}>
+              {headerSubtitle}
+            </ThemedText>
+          ) : null}
+        </View>
       </View>
 
       <FlatList
+        testID={testID}
         data={destinations}
         keyExtractor={(item) => item.icao}
         renderItem={({ item }) => (
@@ -177,9 +208,13 @@ export function DestinationsList({
             airport={item}
             onSelect={onSelectDestination}
             isSelected={selectedDestination?.icao === item.icao}
+            compact={compactCards}
           />
         )}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={[
+          styles.listContent,
+          { paddingBottom: contentBottomInset },
+        ]}
         showsVerticalScrollIndicator={true}
         removeClippedSubviews={true}
         maxToRenderPerBatch={10}

--- a/hooks/useDestinations.ts
+++ b/hooks/useDestinations.ts
@@ -4,7 +4,11 @@
  * @module hooks/useDestinations
  */
 
-import { getDestinationsByFlightTime, getDestinationsInTimeRange } from "@/services/radiusService";
+import {
+  getDestinationsByFlightTime,
+  getDestinationsInTimeBucket,
+  getDestinationsInTimeRange,
+} from "@/services/radiusService";
 import { loadAirports } from "@/services/airportService";
 import { Airport } from "@/types/airport";
 import { Coordinates } from "@/types/location";
@@ -19,6 +23,10 @@ interface UseDestinationsOptions {
   flightTimeInSeconds: number;
   /** Whether to use exact time range (true) or max time (false) */
   useTimeRange?: boolean;
+  /** Whether to use a snapped time bucket instead of cumulative max time */
+  bucketIntervalSeconds?: number;
+  /** Maximum time for the first bucket */
+  initialBucketMaxTime?: number;
   /** Tolerance for time range matching (default: 5%) */
   tolerance?: number;
   /** Debounce delay in milliseconds (default: 300ms) */
@@ -77,8 +85,19 @@ function resolveDestinations(
   originCoords: Coordinates,
   flightTimeInSeconds: number,
   useTimeRange: boolean,
+  bucketIntervalSeconds?: number,
+  initialBucketMaxTime?: number,
   tolerance?: number
 ) {
+  if (bucketIntervalSeconds) {
+    return getDestinationsInTimeBucket(
+      originCoords,
+      flightTimeInSeconds,
+      bucketIntervalSeconds,
+      initialBucketMaxTime
+    );
+  }
+
   return useTimeRange
     ? getDestinationsInTimeRange(originCoords, flightTimeInSeconds, tolerance)
     : getDestinationsByFlightTime(originCoords, flightTimeInSeconds);
@@ -89,6 +108,8 @@ async function fetchDestinations({
   originCoords,
   flightTimeInSeconds,
   useTimeRange,
+  bucketIntervalSeconds,
+  initialBucketMaxTime,
   tolerance,
   setDestinations,
   setError,
@@ -98,6 +119,8 @@ async function fetchDestinations({
   originCoords: Coordinates | null;
   flightTimeInSeconds: number;
   useTimeRange: boolean;
+  bucketIntervalSeconds?: number;
+  initialBucketMaxTime?: number;
   tolerance?: number;
 } & DestinationStateSetters) {
   const requestId = ++requestIdRef.current;
@@ -122,6 +145,8 @@ async function fetchDestinations({
       originCoords,
       flightTimeInSeconds,
       useTimeRange,
+      bucketIntervalSeconds,
+      initialBucketMaxTime,
       tolerance
     );
     if (!isCurrentRequest(requestIdRef, requestId)) {
@@ -174,6 +199,8 @@ export function useDestinations({
   origin,
   flightTimeInSeconds,
   useTimeRange = true,
+  bucketIntervalSeconds,
+  initialBucketMaxTime,
   tolerance,
   debounceMs = 300,
 }: UseDestinationsOptions): UseDestinationsResult {
@@ -195,12 +222,21 @@ export function useDestinations({
       originCoords,
       flightTimeInSeconds,
       useTimeRange,
+      bucketIntervalSeconds,
+      initialBucketMaxTime,
       tolerance,
       setDestinations,
       setError,
       setIsLoading,
     });
-  }, [flightTimeInSeconds, originCoords, tolerance, useTimeRange]);
+  }, [
+    bucketIntervalSeconds,
+    flightTimeInSeconds,
+    initialBucketMaxTime,
+    originCoords,
+    tolerance,
+    useTimeRange,
+  ]);
 
   // Debounced fetch
   useEffect(() => {

--- a/hooks/useDestinations.ts
+++ b/hooks/useDestinations.ts
@@ -21,9 +21,9 @@ interface UseDestinationsOptions {
   origin: Airport | null;
   /** Flight time in seconds */
   flightTimeInSeconds: number;
-  /** Whether to use exact time range (true) or max time (false) */
+  /** Whether to use exact time range (true) or max time (false) when no bucket is configured */
   useTimeRange?: boolean;
-  /** Whether to use a snapped time bucket instead of cumulative max time */
+  /** If provided, bucketed lookup is used regardless of useTimeRange */
   bucketIntervalSeconds?: number;
   /** Maximum time for the first bucket */
   initialBucketMaxTime?: number;
@@ -81,26 +81,42 @@ function isCurrentRequest(
   return requestId === requestIdRef.current;
 }
 
-function resolveDestinations(
-  originCoords: Coordinates,
-  flightTimeInSeconds: number,
-  useTimeRange: boolean,
-  bucketIntervalSeconds?: number,
-  initialBucketMaxTime?: number,
-  tolerance?: number
-) {
+interface DestinationResolutionConfig {
+  originCoords: Coordinates;
+  flightTimeInSeconds: number;
+  useTimeRange: boolean;
+  bucketIntervalSeconds?: number;
+  initialBucketMaxTime?: number;
+  tolerance?: number;
+}
+
+function resolveDestinations({
+  originCoords,
+  flightTimeInSeconds,
+  useTimeRange,
+  bucketIntervalSeconds,
+  initialBucketMaxTime,
+  tolerance,
+}: DestinationResolutionConfig) {
   if (bucketIntervalSeconds) {
-    return getDestinationsInTimeBucket(
-      originCoords,
-      flightTimeInSeconds,
-      bucketIntervalSeconds,
-      initialBucketMaxTime
-    );
+    return getDestinationsInTimeBucket({
+      origin: originCoords,
+      timeInSeconds: flightTimeInSeconds,
+      bucketSizeInSeconds: bucketIntervalSeconds,
+      initialBucketMaxTime,
+    });
   }
 
   return useTimeRange
-    ? getDestinationsInTimeRange(originCoords, flightTimeInSeconds, tolerance)
-    : getDestinationsByFlightTime(originCoords, flightTimeInSeconds);
+    ? getDestinationsInTimeRange({
+        origin: originCoords,
+        timeInSeconds: flightTimeInSeconds,
+        tolerance,
+      })
+    : getDestinationsByFlightTime({
+        origin: originCoords,
+        maxFlightTime: flightTimeInSeconds,
+      });
 }
 
 async function fetchDestinations({
@@ -141,14 +157,14 @@ async function fetchDestinations({
       return;
     }
 
-    const results = resolveDestinations(
+    const results = resolveDestinations({
       originCoords,
       flightTimeInSeconds,
       useTimeRange,
       bucketIntervalSeconds,
       initialBucketMaxTime,
       tolerance
-    );
+    });
     if (!isCurrentRequest(requestIdRef, requestId)) {
       return;
     }

--- a/screens/FlightSetupScreen.tsx
+++ b/screens/FlightSetupScreen.tsx
@@ -1,4 +1,3 @@
-import { AirportCard } from '@/components/airport/AirportCard';
 import { DestinationsList } from '@/components/destinations/DestinationsList';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
@@ -6,131 +5,127 @@ import { TimeSlider } from '@/components/time-slider/TimeSlider';
 import { TimeValue } from '@/components/time-slider/TimeValue';
 import { Button } from '@/components/ui/Button';
 import { IconSymbol } from '@/components/ui/icon-symbol';
-import { Colors, Spacing, Typography } from '@/constants/theme';
+import { BorderRadius, Colors, Spacing, Typography } from '@/constants/theme';
 import { useFlight } from '@/context/FlightContext';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useDestinations } from '@/hooks/useDestinations';
 import { useHomeAirport } from '@/hooks/useHomeAirport';
+import { getFlightTimeBucket } from '@/services/radiusService';
 import type { Airport } from '@/types/airport';
 import { AirportWithFlightTime } from '@/types/radius';
+import { formatTimeValue, TIME_SLIDER_CONFIG } from '@/utils/timeSlider';
 import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import { useRouter } from 'expo-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const FOOTER_HEIGHT = 94;
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  content: {
+  safeArea: {
     flex: 1,
   },
   header: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    marginBottom: Spacing.lg,
     paddingHorizontal: Spacing.lg,
-    paddingTop: Spacing.md,
+    paddingTop: Spacing.xs,
+    paddingBottom: Spacing.md,
   },
   closeButton: {
-    padding: Spacing.sm,
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  section: {
-    marginBottom: Spacing.lg,
-    paddingHorizontal: Spacing.lg,
-  },
-  sectionTitle: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    marginBottom: Spacing.sm,
-    opacity: 0.7,
-  },
-  timeSliderSection: {
-    marginBottom: Spacing.xl,
-    paddingHorizontal: Spacing.lg,
-  },
-  destinationsSection: {
+  body: {
     flex: 1,
-    minHeight: 300,
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing.sm,
+    gap: Spacing.md,
+  },
+  topStack: {
+    gap: Spacing.md,
+  },
+  panel: {
+    borderRadius: BorderRadius.lg,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderWidth: 1,
+  },
+  panelHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.sm,
+  },
+  panelLabel: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.semibold,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  originCodeRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: Spacing.sm,
+  },
+  originIata: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+  },
+  originName: {
+    fontSize: Typography.fontSize.sm,
+    marginTop: 4,
+  },
+  originMeta: {
+    fontSize: Typography.fontSize.sm,
+    marginTop: Spacing.xs,
+  },
+  sliderPanelTop: {
+    marginBottom: Spacing.sm,
+  },
+  sliderValueRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.xs,
+  },
+  bucketPill: {
+    alignSelf: 'flex-start',
+    borderRadius: 999,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 6,
+  },
+  bucketPillText: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.semibold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  destinationsShell: {
+    flex: 1,
+    minHeight: 0,
+    borderRadius: BorderRadius.lg,
+    overflow: 'hidden',
+    borderWidth: 1,
   },
   footer: {
-    padding: Spacing.lg,
-    borderTopWidth: 1,
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.sm,
+    shadowColor: '#0f172a',
+    shadowOffset: { width: 0, height: -6 },
+    shadowOpacity: 0.08,
+    shadowRadius: 16,
+    elevation: 10,
   },
 });
-
-function SectionHeader({ title }: { title: string }) {
-  const colorScheme = useColorScheme();
-  const colors = Colors[colorScheme ?? 'light'];
-
-  return (
-    <ThemedText style={[styles.sectionTitle, { color: colors.textSecondary }]}>
-      {title}
-    </ThemedText>
-  );
-}
-
-function DepartureSection({ homeAirport }: { homeAirport: Airport | null }) {
-  return (
-    <View style={styles.section}>
-      <SectionHeader title="Departure (Origin)" />
-      {homeAirport ? (
-        <AirportCard airport={homeAirport} showEdit={false} />
-      ) : (
-        <ThemedText>No Home Base Selected</ThemedText>
-      )}
-    </View>
-  );
-}
-
-function TimeSliderSection({
-  flightTime,
-  onFlightTimeChange,
-}: {
-  flightTime: number;
-  onFlightTimeChange: (time: number) => void;
-}) {
-  return (
-    <View style={styles.timeSliderSection}>
-      <SectionHeader title="Flight Duration" />
-      <TimeValue seconds={flightTime} />
-      <TimeSlider value={flightTime} onValueChange={onFlightTimeChange} />
-    </View>
-  );
-}
-
-function DestinationsSection({
-  destinations,
-  selectedDestination,
-  onSelectDestination,
-  isLoading,
-  error,
-}: {
-  destinations: AirportWithFlightTime[];
-  selectedDestination: AirportWithFlightTime | null;
-  onSelectDestination: (airport: AirportWithFlightTime) => void;
-  isLoading: boolean;
-  error: string | null;
-}) {
-  return (
-    <View style={styles.destinationsSection}>
-      <View style={{ paddingHorizontal: Spacing.lg, marginBottom: Spacing.sm }}>
-        <SectionHeader title="Available Destinations" />
-      </View>
-      <DestinationsList
-        destinations={destinations}
-        selectedDestination={selectedDestination}
-        onSelectDestination={onSelectDestination}
-        isLoading={isLoading}
-        error={error}
-      />
-    </View>
-  );
-}
 
 function FlightSetupHeader({ onClose }: { onClose: () => void }) {
   const colorScheme = useColorScheme();
@@ -138,16 +133,118 @@ function FlightSetupHeader({ onClose }: { onClose: () => void }) {
 
   return (
     <View style={styles.header}>
-      <ThemedText type="title">Flight Setup</ThemedText>
+      <View>
+        <ThemedText type="title">Flight Setup</ThemedText>
+        <ThemedText style={{ color: colors.textSecondary }}>
+          Pick a flight window, then choose a destination.
+        </ThemedText>
+      </View>
       <TouchableOpacity
         onPress={onClose}
-        style={styles.closeButton}
+        style={[styles.closeButton, { backgroundColor: colors.cardBackground }]}
         accessibilityLabel="Close flight setup"
         accessibilityRole="button"
         hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
       >
-        <IconSymbol name="xmark" size={24} color={colors.text} />
+        <IconSymbol name="xmark" size={20} color={colors.text} />
       </TouchableOpacity>
+    </View>
+  );
+}
+
+function OriginSummaryCard({ airport }: { airport: Airport | null }) {
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'light'];
+
+  if (!airport) {
+    return (
+      <View
+        style={[
+          styles.panel,
+          {
+            backgroundColor: colors.cardBackground,
+            borderColor: colors.border,
+          },
+        ]}
+      >
+        <ThemedText style={[styles.panelLabel, { color: colors.textSecondary }]}>
+          Departure
+        </ThemedText>
+        <ThemedText>No home base selected</ThemedText>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.panel,
+        {
+          backgroundColor: colors.cardBackground,
+          borderColor: colors.border,
+        },
+      ]}
+    >
+      <View style={styles.panelHeader}>
+        <ThemedText style={[styles.panelLabel, { color: colors.textSecondary }]}>
+          Departure
+        </ThemedText>
+        <ThemedText style={[styles.originIata, { color: colors.textSecondary }]}>
+          {airport.city}
+        </ThemedText>
+      </View>
+      <View style={styles.originCodeRow}>
+        <ThemedText type="title">{airport.icao}</ThemedText>
+        {!!airport.iata && (
+          <ThemedText style={[styles.originIata, { color: colors.primary }]}>
+            {airport.iata}
+          </ThemedText>
+        )}
+      </View>
+      <ThemedText style={styles.originName}>{airport.name}</ThemedText>
+      <ThemedText style={[styles.originMeta, { color: colors.textSecondary }]}>
+        {airport.state ? `${airport.city}, ${airport.state}` : airport.city}
+      </ThemedText>
+    </View>
+  );
+}
+
+function FlightTimeCard({
+  flightTime,
+  onFlightTimeChange,
+  bucketLabel,
+}: {
+  flightTime: number;
+  onFlightTimeChange: (time: number) => void;
+  bucketLabel: string;
+}) {
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'light'];
+
+  return (
+    <View
+      style={[
+        styles.panel,
+        {
+          backgroundColor: colors.cardBackground,
+          borderColor: colors.border,
+        },
+      ]}
+    >
+      <View style={styles.sliderPanelTop}>
+        <View style={styles.sliderValueRow}>
+          <ThemedText style={[styles.panelLabel, { color: colors.textSecondary }]}>
+            Flight Window
+          </ThemedText>
+          <View style={[styles.bucketPill, { backgroundColor: colors.surfaceElevated }]}>
+            <ThemedText style={[styles.bucketPillText, { color: colors.primary }]}>
+              {bucketLabel}
+            </ThemedText>
+          </View>
+        </View>
+        <TimeValue seconds={flightTime} />
+      </View>
+      <TimeSlider value={flightTime} onValueChange={onFlightTimeChange} />
     </View>
   );
 }
@@ -161,62 +258,51 @@ function FlightSetupFooter({
 }) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const insets = useSafeAreaInsets();
 
   return (
-    <View style={[styles.footer, { borderTopColor: colors.border }]}>
+    <View
+      style={[
+        styles.footer,
+        {
+          backgroundColor: colors.background,
+          paddingBottom: Math.max(insets.bottom, Spacing.md),
+        },
+      ]}
+    >
       <Button
         title="Review Flight"
         onPress={onStart}
-        size="lg"
+        size="md"
         disabled={isDisabled}
+        testID="review-flight-button"
       />
     </View>
   );
 }
 
-function FlightSetupContent({
-  homeAirport,
-  flightTime,
-  onFlightTimeChange,
-  destinations,
-  selectedDestination,
-  onSelectDestination,
-  isLoadingDestinations,
-  destinationsError,
-  onClose,
-}: {
-  homeAirport: Airport | null;
-  flightTime: number;
-  onFlightTimeChange: (time: number) => void;
-  destinations: AirportWithFlightTime[];
-  selectedDestination: AirportWithFlightTime | null;
-  onSelectDestination: (airport: AirportWithFlightTime) => void;
-  isLoadingDestinations: boolean;
-  destinationsError: string | null;
-  onClose: () => void;
-}) {
-  return (
-    <View style={styles.content}>
-      <FlightSetupHeader onClose={onClose} />
-      <DepartureSection homeAirport={homeAirport} />
-      <TimeSliderSection
-        flightTime={flightTime}
-        onFlightTimeChange={onFlightTimeChange}
-      />
-      <DestinationsSection
-        destinations={destinations}
-        selectedDestination={selectedDestination}
-        onSelectDestination={onSelectDestination}
-        isLoading={isLoadingDestinations}
-        error={destinationsError}
-      />
-    </View>
+function formatBucketLabel(flightTime: number): string {
+  const bucket = getFlightTimeBucket(
+    flightTime,
+    TIME_SLIDER_CONFIG.SNAP_INTERVAL,
+    TIME_SLIDER_CONFIG.MIN_TIME
   );
+  const maxLabel = formatTimeValue(bucket.maxTimeInSeconds).formatted;
+
+  if (bucket.minTimeInSeconds === 0) {
+    return `Up to ${maxLabel}`;
+  }
+
+  const minLabel = formatTimeValue(bucket.minTimeInSeconds).formatted;
+  return `${minLabel} - ${maxLabel}`;
 }
 
 export default function FlightSetupScreen() {
   const { homeAirport } = useHomeAirport();
   const router = useRouter();
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'light'];
+  const insets = useSafeAreaInsets();
   const {
     origin,
     destination,
@@ -226,17 +312,14 @@ export default function FlightSetupScreen() {
     setFlightDuration,
   } = useFlight();
 
-  // Local state for slider value (updates immediately)
   const [localFlightTime, setLocalFlightTime] = useState(flightDuration);
 
-  // Sync origin with home airport
   useEffect(() => {
     if (homeAirport && (!origin || origin.icao !== homeAirport.icao)) {
       setOrigin(homeAirport);
     }
   }, [homeAirport, origin, setOrigin]);
 
-  // Fetch destinations based on current flight time
   const {
     destinations,
     isLoading: isLoadingDestinations,
@@ -245,13 +328,16 @@ export default function FlightSetupScreen() {
     origin: homeAirport,
     flightTimeInSeconds: localFlightTime,
     useTimeRange: false,
+    bucketIntervalSeconds: TIME_SLIDER_CONFIG.SNAP_INTERVAL,
+    initialBucketMaxTime: TIME_SLIDER_CONFIG.MIN_TIME,
   });
 
-  // Find the selected destination in the destinations array
-  // (needed because destination from context is Airport, but we need AirportWithFlightTime)
   const selectedDestinationWithTime = destination
-    ? destinations.find((d) => d.icao === destination.icao) || null
+    ? destinations.find((currentDestination) => currentDestination.icao === destination.icao) || null
     : null;
+
+  const bucketLabel = useMemo(() => formatBucketLabel(localFlightTime), [localFlightTime]);
+  const footerInset = FOOTER_HEIGHT + insets.bottom + Spacing.xl;
 
   const handleFlightTimeChange = useCallback((time: number) => {
     setLocalFlightTime(time);
@@ -268,40 +354,55 @@ export default function FlightSetupScreen() {
   const handleReviewFlight = useCallback(() => {
     if (!destination) return;
 
-    impactAsync(ImpactFeedbackStyle.Heavy).catch(() => {
-      // Ignore haptics error
-    });
-
-    // Navigate to flight review screen
+    impactAsync(ImpactFeedbackStyle.Heavy).catch(() => undefined);
     router.push('/flight/review');
   }, [destination, router]);
 
   const handleClose = useCallback(() => {
-    impactAsync(ImpactFeedbackStyle.Light).catch(() => {
-      // Ignore haptics error
-    });
+    impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
     router.back();
   }, [router]);
 
-  const isStartDisabled = !destination || !homeAirport;
-
   return (
     <ThemedView style={styles.container}>
-      <SafeAreaView style={{ flex: 1 }}>
-        <FlightSetupContent
-          homeAirport={homeAirport}
-          flightTime={localFlightTime}
-          onFlightTimeChange={handleFlightTimeChange}
-          destinations={destinations}
-          selectedDestination={selectedDestinationWithTime}
-          onSelectDestination={handleSelectDestination}
-          isLoadingDestinations={isLoadingDestinations}
-          destinationsError={destinationsError}
-          onClose={handleClose}
-        />
+      <SafeAreaView style={styles.safeArea}>
+        <FlightSetupHeader onClose={handleClose} />
+        <View style={styles.body}>
+          <View style={styles.topStack}>
+            <OriginSummaryCard airport={homeAirport} />
+            <FlightTimeCard
+              flightTime={localFlightTime}
+              onFlightTimeChange={handleFlightTimeChange}
+              bucketLabel={bucketLabel}
+            />
+          </View>
+
+          <View
+            style={[
+              styles.destinationsShell,
+              {
+                backgroundColor: colors.cardBackground,
+                borderColor: colors.border,
+              },
+            ]}
+          >
+            <DestinationsList
+              destinations={destinations}
+              selectedDestination={selectedDestinationWithTime}
+              onSelectDestination={handleSelectDestination}
+              isLoading={isLoadingDestinations}
+              error={destinationsError}
+              compactCards={true}
+              contentBottomInset={footerInset}
+              headerSubtitle={bucketLabel}
+              testID="destinations-list"
+            />
+          </View>
+        </View>
+
         <FlightSetupFooter
           onStart={handleReviewFlight}
-          isDisabled={isStartDisabled}
+          isDisabled={!destination || !homeAirport}
         />
       </SafeAreaView>
     </ThemedView>

--- a/screens/FlightSetupScreen.tsx
+++ b/screens/FlightSetupScreen.tsx
@@ -12,15 +12,14 @@ import { useDestinations } from '@/hooks/useDestinations';
 import { useHomeAirport } from '@/hooks/useHomeAirport';
 import { getFlightTimeBucket } from '@/services/radiusService';
 import type { Airport } from '@/types/airport';
-import { AirportWithFlightTime } from '@/types/radius';
+import type { AirportWithFlightTime } from '@/types/radius';
 import { formatTimeValue, TIME_SLIDER_CONFIG } from '@/utils/timeSlider';
 import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import { useRouter } from 'expo-router';
+import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { LayoutChangeEvent, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
-
-const FOOTER_HEIGHT = 94;
 
 const styles = StyleSheet.create({
   container: {
@@ -195,7 +194,7 @@ function OriginSummaryCard({ airport }: { airport: Airport | null }) {
       </View>
       <View style={styles.originCodeRow}>
         <ThemedText type="title">{airport.icao}</ThemedText>
-        {!!airport.iata && (
+        {Boolean(airport.iata) && (
           <ThemedText style={[styles.originIata, { color: colors.primary }]}>
             {airport.iata}
           </ThemedText>
@@ -220,6 +219,13 @@ function FlightTimeCard({
 }) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const bucketPill = (
+    <View style={[styles.bucketPill, { backgroundColor: colors.surfaceElevated }]}>
+      <ThemedText style={[styles.bucketPillText, { color: colors.primary }]}>
+        {bucketLabel}
+      </ThemedText>
+    </View>
+  );
 
   return (
     <View
@@ -232,16 +238,7 @@ function FlightTimeCard({
       ]}
     >
       <View style={styles.sliderPanelTop}>
-        <View style={styles.sliderValueRow}>
-          <ThemedText style={[styles.panelLabel, { color: colors.textSecondary }]}>
-            Flight Window
-          </ThemedText>
-          <View style={[styles.bucketPill, { backgroundColor: colors.surfaceElevated }]}>
-            <ThemedText style={[styles.bucketPillText, { color: colors.primary }]}>
-              {bucketLabel}
-            </ThemedText>
-          </View>
-        </View>
+        <FlightTimeCardHeader bucketPill={bucketPill} textSecondary={colors.textSecondary} />
         <TimeValue seconds={flightTime} />
       </View>
       <TimeSlider value={flightTime} onValueChange={onFlightTimeChange} />
@@ -252,9 +249,11 @@ function FlightTimeCard({
 function FlightSetupFooter({
   onStart,
   isDisabled,
+  onLayout,
 }: {
   onStart: () => void;
   isDisabled: boolean;
+  onLayout: (event: LayoutChangeEvent) => void;
 }) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
@@ -262,6 +261,7 @@ function FlightSetupFooter({
 
   return (
     <View
+      onLayout={onLayout}
       style={[
         styles.footer,
         {
@@ -282,11 +282,11 @@ function FlightSetupFooter({
 }
 
 function formatBucketLabel(flightTime: number): string {
-  const bucket = getFlightTimeBucket(
-    flightTime,
-    TIME_SLIDER_CONFIG.SNAP_INTERVAL,
-    TIME_SLIDER_CONFIG.MIN_TIME
-  );
+  const bucket = getFlightTimeBucket({
+    timeInSeconds: flightTime,
+    bucketSizeInSeconds: TIME_SLIDER_CONFIG.SNAP_INTERVAL,
+    initialBucketMaxTime: TIME_SLIDER_CONFIG.MIN_TIME,
+  });
   const maxLabel = formatTimeValue(bucket.maxTimeInSeconds).formatted;
 
   if (bucket.minTimeInSeconds === 0) {
@@ -302,7 +302,6 @@ export default function FlightSetupScreen() {
   const router = useRouter();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
-  const insets = useSafeAreaInsets();
   const {
     origin,
     destination,
@@ -313,6 +312,7 @@ export default function FlightSetupScreen() {
   } = useFlight();
 
   const [localFlightTime, setLocalFlightTime] = useState(flightDuration);
+  const [footerHeight, setFooterHeight] = useState(0);
 
   useEffect(() => {
     if (homeAirport && (!origin || origin.icao !== homeAirport.icao)) {
@@ -337,7 +337,7 @@ export default function FlightSetupScreen() {
     : null;
 
   const bucketLabel = useMemo(() => formatBucketLabel(localFlightTime), [localFlightTime]);
-  const footerInset = FOOTER_HEIGHT + insets.bottom + Spacing.xl;
+  const footerInset = footerHeight + Spacing.xl;
 
   const handleFlightTimeChange = useCallback((time: number) => {
     setLocalFlightTime(time);
@@ -362,6 +362,13 @@ export default function FlightSetupScreen() {
     impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
     router.back();
   }, [router]);
+
+  const handleFooterLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = event.nativeEvent.layout.height;
+    setFooterHeight((currentHeight) => {
+      return currentHeight === nextHeight ? currentHeight : nextHeight;
+    });
+  }, []);
 
   return (
     <ThemedView style={styles.container}>
@@ -392,7 +399,7 @@ export default function FlightSetupScreen() {
               onSelectDestination={handleSelectDestination}
               isLoading={isLoadingDestinations}
               error={destinationsError}
-              compactCards={true}
+              compactCards
               contentBottomInset={footerInset}
               headerSubtitle={bucketLabel}
               testID="destinations-list"
@@ -403,8 +410,26 @@ export default function FlightSetupScreen() {
         <FlightSetupFooter
           onStart={handleReviewFlight}
           isDisabled={!destination || !homeAirport}
+          onLayout={handleFooterLayout}
         />
       </SafeAreaView>
     </ThemedView>
+  );
+}
+
+function FlightTimeCardHeader({
+  bucketPill,
+  textSecondary,
+}: {
+  bucketPill: ReactNode;
+  textSecondary: string;
+}) {
+  return (
+    <View style={styles.sliderValueRow}>
+      <ThemedText style={[styles.panelLabel, { color: textSecondary }]}>
+        Flight Window
+      </ThemedText>
+      {bucketPill}
+    </View>
   );
 }

--- a/services/radiusService.ts
+++ b/services/radiusService.ts
@@ -33,6 +33,38 @@ export interface FlightTimeBucket {
   maxTimeInSeconds: number;
 }
 
+interface TimeConfig {
+  timeInSeconds: number;
+}
+
+interface FlightTimeBucketConfig extends TimeConfig {
+  bucketSizeInSeconds?: number;
+  initialBucketMaxTime?: number;
+}
+
+interface TimeRangeConfig extends TimeConfig {
+  origin: Coordinates;
+  tolerance?: number;
+}
+
+interface MaxFlightTimeConfig {
+  origin: Coordinates;
+  maxFlightTime: number;
+}
+
+interface TimeBucketLookupConfig extends FlightTimeBucketConfig {
+  origin: Coordinates;
+}
+
+interface DistanceConfig {
+  distanceInMiles: number;
+}
+
+interface FlightBucketMembershipConfig {
+  flightTime: number;
+  bucket: FlightTimeBucket;
+}
+
 const PRIORITY_KEYWORDS = [
   ["international", 0],
   ["world", 0],
@@ -57,7 +89,7 @@ const PRIORITY_KEYWORDS = [
  * calculateMaxDistance(18000); // Returns ~2062.5 miles
  * ```
  */
-export function calculateMaxDistance(timeInSeconds: number): number {
+export function calculateMaxDistance({ timeInSeconds }: TimeConfig): number {
   // Subtract overhead time (takeoff, landing, taxi)
   const cruiseTimeSeconds = Math.max(
     0,
@@ -90,7 +122,7 @@ export function calculateMaxDistance(timeInSeconds: number): number {
  * estimateFlightTime(2500); // Returns ~21500 seconds (~6 hours)
  * ```
  */
-export function estimateFlightTime(distanceInMiles: number): number {
+export function estimateFlightTime({ distanceInMiles }: DistanceConfig): number {
   // Calculate cruise time
   const cruiseTimeHours = distanceInMiles / FLIGHT_CONSTANTS.CRUISE_SPEED_MPH;
   const cruiseTimeSeconds = cruiseTimeHours * 3600;
@@ -107,8 +139,8 @@ export function estimateFlightTime(distanceInMiles: number): number {
  * @param timeInSeconds - Flight duration in seconds
  * @returns Flight estimation details
  */
-export function getFlightEstimate(timeInSeconds: number): FlightEstimate {
-  const distanceInMiles = calculateMaxDistance(timeInSeconds);
+export function getFlightEstimate({ timeInSeconds }: TimeConfig): FlightEstimate {
+  const distanceInMiles = calculateMaxDistance({ timeInSeconds });
 
   return {
     timeInSeconds,
@@ -127,7 +159,7 @@ function mapAirportsWithFlightTime(
       lat: airport.lat,
       lon: airport.lon,
     });
-    const flightTime = estimateFlightTime(distance);
+    const flightTime = estimateFlightTime({ distanceInMiles: distance });
 
     return {
       ...airport,
@@ -162,12 +194,19 @@ export function prioritizeDestinations(
   });
 }
 
-export function getFlightTimeBucket(
-  timeInSeconds: number,
-  bucketSizeInSeconds: number = TIME_SLIDER_CONFIG.SNAP_INTERVAL,
-  initialBucketMaxTime: number = TIME_SLIDER_CONFIG.MIN_TIME
-): FlightTimeBucket {
-  if (timeInSeconds <= initialBucketMaxTime) {
+export function getFlightTimeBucket({
+  timeInSeconds,
+  bucketSizeInSeconds = TIME_SLIDER_CONFIG.SNAP_INTERVAL,
+  initialBucketMaxTime = TIME_SLIDER_CONFIG.MIN_TIME,
+}: FlightTimeBucketConfig): FlightTimeBucket {
+  const boundedTime = Math.max(initialBucketMaxTime, timeInSeconds);
+  const stepsFromInitialBucket = Math.ceil(
+    (boundedTime - initialBucketMaxTime) / bucketSizeInSeconds
+  );
+  const snappedMaxTime =
+    initialBucketMaxTime + stepsFromInitialBucket * bucketSizeInSeconds;
+
+  if (snappedMaxTime <= initialBucketMaxTime) {
     return {
       minTimeInSeconds: 0,
       maxTimeInSeconds: initialBucketMaxTime,
@@ -175,15 +214,15 @@ export function getFlightTimeBucket(
   }
 
   return {
-    minTimeInSeconds: timeInSeconds - bucketSizeInSeconds,
-    maxTimeInSeconds: timeInSeconds,
+    minTimeInSeconds: snappedMaxTime - bucketSizeInSeconds,
+    maxTimeInSeconds: snappedMaxTime,
   };
 }
 
-function isInFlightTimeBucket(
-  flightTime: number,
-  bucket: FlightTimeBucket
-): boolean {
+function isInFlightTimeBucket({
+  flightTime,
+  bucket,
+}: FlightBucketMembershipConfig): boolean {
   if (bucket.minTimeInSeconds === 0) {
     return flightTime <= bucket.maxTimeInSeconds;
   }
@@ -214,13 +253,13 @@ function isInFlightTimeBucket(
  * // Returns airports within ~2000 miles (includes LA, Seattle, Miami, etc.)
  * ```
  */
-export function getDestinationsInTimeRange(
-  origin: Coordinates,
-  timeInSeconds: number,
-  tolerance: number = FLIGHT_CONSTANTS.DEFAULT_TOLERANCE
-): AirportWithFlightTime[] {
+export function getDestinationsInTimeRange({
+  origin,
+  timeInSeconds,
+  tolerance = FLIGHT_CONSTANTS.DEFAULT_TOLERANCE,
+}: TimeRangeConfig): AirportWithFlightTime[] {
   // Calculate maximum distance with tolerance
-  const baseDistance = calculateMaxDistance(timeInSeconds);
+  const baseDistance = calculateMaxDistance({ timeInSeconds });
   const maxDistance = baseDistance * (1 + tolerance);
 
   // Get airports within distance range
@@ -259,12 +298,12 @@ export function getDestinationsInTimeRange(
  * // Returns all airports within ~525 miles
  * ```
  */
-export function getDestinationsByFlightTime(
-  origin: Coordinates,
-  maxFlightTime: number
-): AirportWithFlightTime[] {
+export function getDestinationsByFlightTime({
+  origin,
+  maxFlightTime,
+}: MaxFlightTimeConfig): AirportWithFlightTime[] {
   // Calculate maximum distance
-  const maxDistance = calculateMaxDistance(maxFlightTime);
+  const maxDistance = calculateMaxDistance({ timeInSeconds: maxFlightTime });
 
   // Get all airports within distance
   const airports = getAirportsWithinDistance(origin, maxDistance);
@@ -276,18 +315,22 @@ export function getDestinationsByFlightTime(
   return airportsWithTime.sort((a, b) => a.distance - b.distance);
 }
 
-export function getDestinationsInTimeBucket(
-  origin: Coordinates,
-  timeInSeconds: number,
-  bucketSizeInSeconds: number = TIME_SLIDER_CONFIG.SNAP_INTERVAL,
-  initialBucketMaxTime: number = TIME_SLIDER_CONFIG.MIN_TIME
-): AirportWithFlightTime[] {
-  const bucket = getFlightTimeBucket(timeInSeconds, bucketSizeInSeconds, initialBucketMaxTime);
-  const maxDistance = calculateMaxDistance(bucket.maxTimeInSeconds);
+export function getDestinationsInTimeBucket({
+  origin,
+  timeInSeconds,
+  bucketSizeInSeconds = TIME_SLIDER_CONFIG.SNAP_INTERVAL,
+  initialBucketMaxTime = TIME_SLIDER_CONFIG.MIN_TIME,
+}: TimeBucketLookupConfig): AirportWithFlightTime[] {
+  const bucket = getFlightTimeBucket({
+    timeInSeconds,
+    bucketSizeInSeconds,
+    initialBucketMaxTime,
+  });
+  const maxDistance = calculateMaxDistance({ timeInSeconds: bucket.maxTimeInSeconds });
   const airports = getAirportsWithinDistance(origin, maxDistance);
   const airportsWithTime = mapAirportsWithFlightTime(origin, airports);
   const filtered = airportsWithTime.filter((airport) => {
-    return isInFlightTimeBucket(airport.flightTime, bucket);
+    return isInFlightTimeBucket({ flightTime: airport.flightTime, bucket });
   });
 
   return prioritizeDestinations(filtered);

--- a/services/radiusService.ts
+++ b/services/radiusService.ts
@@ -13,6 +13,7 @@
 import { Coordinates } from "@/types/location";
 import { AirportWithFlightTime, FlightEstimate } from "@/types/radius";
 import { calculateDistance } from "@/utils/distance";
+import { TIME_SLIDER_CONFIG } from "@/utils/timeSlider";
 import { getAirportsWithinDistance } from "./airportService";
 
 /**
@@ -26,6 +27,18 @@ export const FLIGHT_CONSTANTS = {
   /** Default tolerance for flight time variation (±5%) */
   DEFAULT_TOLERANCE: 0.05,
 } as const;
+
+export interface FlightTimeBucket {
+  minTimeInSeconds: number;
+  maxTimeInSeconds: number;
+}
+
+const PRIORITY_KEYWORDS = [
+  ["international", 0],
+  ["world", 0],
+  ["national", 1],
+  ["regional", 2],
+] as const;
 
 /**
  * Calculates the maximum distance that can be traveled in the given flight time.
@@ -105,6 +118,79 @@ export function getFlightEstimate(timeInSeconds: number): FlightEstimate {
   };
 }
 
+function mapAirportsWithFlightTime(
+  origin: Coordinates,
+  airports: ReturnType<typeof getAirportsWithinDistance>
+): AirportWithFlightTime[] {
+  return airports.map((airport) => {
+    const distance = calculateDistance(origin, {
+      lat: airport.lat,
+      lon: airport.lon,
+    });
+    const flightTime = estimateFlightTime(distance);
+
+    return {
+      ...airport,
+      distance,
+      flightTime,
+    };
+  });
+}
+
+function getAirportPriority(airport: Pick<AirportWithFlightTime, "name">): number {
+  const normalizedName = airport.name.toLowerCase();
+
+  for (const [keyword, priority] of PRIORITY_KEYWORDS) {
+    if (normalizedName.includes(keyword)) {
+      return priority;
+    }
+  }
+
+  return PRIORITY_KEYWORDS.length;
+}
+
+export function prioritizeDestinations(
+  destinations: AirportWithFlightTime[]
+): AirportWithFlightTime[] {
+  return [...destinations].sort((left, right) => {
+    const priorityDelta = getAirportPriority(left) - getAirportPriority(right);
+    if (priorityDelta !== 0) {
+      return priorityDelta;
+    }
+
+    return left.distance - right.distance;
+  });
+}
+
+export function getFlightTimeBucket(
+  timeInSeconds: number,
+  bucketSizeInSeconds: number = TIME_SLIDER_CONFIG.SNAP_INTERVAL,
+  initialBucketMaxTime: number = TIME_SLIDER_CONFIG.MIN_TIME
+): FlightTimeBucket {
+  if (timeInSeconds <= initialBucketMaxTime) {
+    return {
+      minTimeInSeconds: 0,
+      maxTimeInSeconds: initialBucketMaxTime,
+    };
+  }
+
+  return {
+    minTimeInSeconds: timeInSeconds - bucketSizeInSeconds,
+    maxTimeInSeconds: timeInSeconds,
+  };
+}
+
+function isInFlightTimeBucket(
+  flightTime: number,
+  bucket: FlightTimeBucket
+): boolean {
+  if (bucket.minTimeInSeconds === 0) {
+    return flightTime <= bucket.maxTimeInSeconds;
+  }
+
+  return flightTime > bucket.minTimeInSeconds && flightTime <= bucket.maxTimeInSeconds;
+}
+
 /**
  * Finds airports reachable within the specified flight time from an origin.
  *
@@ -141,19 +227,7 @@ export function getDestinationsInTimeRange(
   const airports = getAirportsWithinDistance(origin, maxDistance);
 
   // Map to AirportWithFlightTime and add flight estimates
-  const airportsWithTime: AirportWithFlightTime[] = airports.map((airport) => {
-    const distance = calculateDistance(origin, {
-      lat: airport.lat,
-      lon: airport.lon,
-    });
-    const flightTime = estimateFlightTime(distance);
-
-    return {
-      ...airport,
-      distance,
-      flightTime,
-    };
-  });
+  const airportsWithTime = mapAirportsWithFlightTime(origin, airports);
 
   // Filter to only include airports within the time range (considering tolerance)
   const minTime = timeInSeconds * (1 - tolerance);
@@ -196,20 +270,25 @@ export function getDestinationsByFlightTime(
   const airports = getAirportsWithinDistance(origin, maxDistance);
 
   // Map to AirportWithFlightTime with flight estimates
-  const airportsWithTime: AirportWithFlightTime[] = airports.map((airport) => {
-    const distance = calculateDistance(origin, {
-      lat: airport.lat,
-      lon: airport.lon,
-    });
-    const flightTime = estimateFlightTime(distance);
-
-    return {
-      ...airport,
-      distance,
-      flightTime,
-    };
-  });
+  const airportsWithTime = mapAirportsWithFlightTime(origin, airports);
 
   // Sort by distance (closest first)
   return airportsWithTime.sort((a, b) => a.distance - b.distance);
+}
+
+export function getDestinationsInTimeBucket(
+  origin: Coordinates,
+  timeInSeconds: number,
+  bucketSizeInSeconds: number = TIME_SLIDER_CONFIG.SNAP_INTERVAL,
+  initialBucketMaxTime: number = TIME_SLIDER_CONFIG.MIN_TIME
+): AirportWithFlightTime[] {
+  const bucket = getFlightTimeBucket(timeInSeconds, bucketSizeInSeconds, initialBucketMaxTime);
+  const maxDistance = calculateMaxDistance(bucket.maxTimeInSeconds);
+  const airports = getAirportsWithinDistance(origin, maxDistance);
+  const airportsWithTime = mapAirportsWithFlightTime(origin, airports);
+  const filtered = airportsWithTime.filter((airport) => {
+    return isInFlightTimeBucket(airport.flightTime, bucket);
+  });
+
+  return prioritizeDestinations(filtered);
 }


### PR DESCRIPTION
## Summary
- redesign the Flight Setup screen into a compact mobile-first layout with the destination list as the main scroll region
- switch destination lookup to 10-minute buckets with a 30-minute first-bucket exception and keyword-based airport prioritization
- add regression coverage for bucket filtering, ranking, and the updated Flight Setup screen behavior

## Testing
- npx tsc --noEmit
- npm test -- --runInBand
- npm run lint
