### PR TITLE
feat: split flight setup into a two-step wizard

### DIFF
--- a/__tests__/screens/FlightDestinationScreen.test.tsx
+++ b/__tests__/screens/FlightDestinationScreen.test.tsx
@@ -185,7 +185,7 @@ describe('FlightDestinationScreen', () => {
       destination: null,
       flightDuration: 3600,
     };
-    mockSetDestination.mockResolvedValue(undefined);
+    mockSetDestination.mockImplementation(() => Promise.resolve());
   });
 
   it('shows the destination summary and keeps review disabled until a destination is selected', () => {

--- a/__tests__/screens/FlightDestinationScreen.test.tsx
+++ b/__tests__/screens/FlightDestinationScreen.test.tsx
@@ -1,0 +1,243 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import FlightDestinationScreen from '@/screens/FlightDestinationScreen';
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockSetDestination = jest.fn();
+
+const mockOrigin = {
+  icao: 'KOKC',
+  iata: 'OKC',
+  name: 'Will Rogers World Airport',
+  city: 'Oklahoma City',
+  country: 'US',
+  state: 'OK',
+  lat: 35.3931,
+  lon: -97.6007,
+  elevation: 1295,
+  tz: 'America/Chicago',
+};
+
+const mockDestinations = [
+  {
+    icao: 'KOUN',
+    iata: 'OUN',
+    name: 'University of Oklahoma Westheimer Airport',
+    city: 'Norman',
+    country: 'US',
+    state: 'OK',
+    lat: 35.2456,
+    lon: -97.4721,
+    elevation: 1162,
+    tz: 'America/Chicago',
+    distance: 20,
+    flightTime: 2400,
+  },
+];
+
+let mockFlightState = {
+  origin: mockOrigin,
+  destination: null as (typeof mockDestinations)[number] | null,
+  flightDuration: 3600,
+};
+
+jest.mock('react-native', () => {
+  type HostProps = React.PropsWithChildren<Record<string, unknown>>;
+  const createHostComponent = (name: string) => {
+    return ({ children, ...props }: HostProps) => React.createElement(name, props, children);
+  };
+
+  return {
+    Platform: {
+      OS: 'ios',
+      select: (mapping: Record<string, unknown>) => mapping.ios ?? mapping.default,
+    },
+    View: createHostComponent('View'),
+    Text: createHostComponent('Text'),
+    Pressable: createHostComponent('Pressable'),
+    TouchableOpacity: createHostComponent('TouchableOpacity'),
+    SafeAreaView: createHostComponent('SafeAreaView'),
+    StyleSheet: {
+      create: (styles: Record<string, unknown>) => styles,
+    },
+  };
+});
+
+jest.mock('@/components/destinations/DestinationsList', () => ({
+  DestinationsList: ({
+    onSelectDestination,
+  }: {
+    onSelectDestination: (airport: (typeof mockDestinations)[number]) => void;
+  }) => {
+    return React.createElement(
+      'Pressable',
+      {
+        testID: 'mock-destination-list',
+        onPress: () => onSelectDestination(mockDestinations[0]),
+      },
+      React.createElement('Text', { testID: 'destinations-state' }, mockDestinations[0].city)
+    );
+  },
+}));
+
+jest.mock('@/components/themed-text', () => ({
+  ThemedText: ({ children, testID, style }: { children: React.ReactNode; testID?: string; style?: unknown }) => {
+    return React.createElement('Text', { testID, style }, children);
+  },
+}));
+
+jest.mock('@/components/themed-view', () => ({
+  ThemedView: ({ children }: { children: React.ReactNode }) => {
+    return React.createElement('View', null, children);
+  },
+}));
+
+jest.mock('@/components/ui/Button', () => ({
+  Button: ({
+    title,
+    onPress,
+    testID,
+    disabled,
+  }: {
+    title: string;
+    onPress: () => void;
+    testID?: string;
+    disabled?: boolean;
+  }) => {
+    return React.createElement(
+      'Pressable',
+      {
+        testID,
+        onPress,
+        disabled,
+      },
+      React.createElement('Text', null, title)
+    );
+  },
+}));
+
+jest.mock('@/components/ui/icon-symbol', () => ({
+  IconSymbol: () => React.createElement('Text', { testID: 'icon-symbol' }, 'icon'),
+}));
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn().mockImplementation(() => Promise.resolve()),
+  ImpactFeedbackStyle: {
+    Light: 'light',
+    Heavy: 'heavy',
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => {
+    return React.createElement('SafeAreaView', props, children);
+  },
+  useSafeAreaInsets: () => ({
+    top: 0,
+    right: 0,
+    bottom: 20,
+    left: 0,
+  }),
+}));
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('@/hooks/useDestinations', () => ({
+  useDestinations: () => ({
+    destinations: mockDestinations,
+    isLoading: false,
+    error: null,
+    refresh: jest.fn(),
+  }),
+}));
+
+jest.mock('@/context/FlightContext', () => ({
+  useFlight: () => ({
+    ...mockFlightState,
+    setDestination: mockSetDestination,
+  }),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    back: mockBack,
+    push: mockPush,
+  }),
+}));
+
+type TestRendererInstance = ReturnType<typeof TestRenderer.create>;
+
+function hasText(renderer: TestRendererInstance, expectedText: string) {
+  return renderer.root.findAllByType('Text').some((node: { children: Array<string | number> }) => {
+    return node.children.join('') === expectedText;
+  });
+}
+
+describe('FlightDestinationScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFlightState = {
+      origin: mockOrigin,
+      destination: null,
+      flightDuration: 3600,
+    };
+    mockSetDestination.mockResolvedValue(undefined);
+  });
+
+  it('shows the destination summary and keeps review disabled until a destination is selected', () => {
+    let renderer: TestRendererInstance | null = null;
+
+    act(() => {
+      renderer = TestRenderer.create(<FlightDestinationScreen />);
+    });
+
+    if (!renderer) {
+      throw new Error('Screen renderer not initialized');
+    }
+
+    expect(hasText(renderer, 'KOKC')).toBe(true);
+    expect(hasText(renderer, '50m - 1h 0m')).toBe(true);
+    expect(renderer.root.findByProps({ testID: 'review-flight-button' }).props.disabled).toBe(true);
+  });
+
+  it('selects a destination and enables review when one is already selected', async () => {
+    let renderer: TestRendererInstance | null = null;
+
+    act(() => {
+      renderer = TestRenderer.create(<FlightDestinationScreen />);
+    });
+
+    if (!renderer) {
+      throw new Error('Screen renderer not initialized');
+    }
+
+    act(() => {
+      renderer.root.findByProps({ testID: 'mock-destination-list' }).props.onPress();
+    });
+
+    expect(mockSetDestination).toHaveBeenCalledWith(mockDestinations[0]);
+
+    mockFlightState = {
+      origin: mockOrigin,
+      destination: mockDestinations[0],
+      flightDuration: 3600,
+    };
+
+    act(() => {
+      renderer.update(<FlightDestinationScreen />);
+    });
+
+    expect(renderer.root.findByProps({ testID: 'review-flight-button' }).props.disabled).toBe(false);
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'review-flight-button' }).props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/flight/review');
+  });
+});

--- a/__tests__/screens/FlightSetupScreen.test.tsx
+++ b/__tests__/screens/FlightSetupScreen.test.tsx
@@ -148,9 +148,9 @@ type TestRendererInstance = ReturnType<typeof TestRenderer.create>;
 describe('FlightSetupScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSetOrigin.mockResolvedValue(undefined);
-    mockSetDestination.mockResolvedValue(undefined);
-    mockSetFlightDuration.mockResolvedValue(undefined);
+    mockSetOrigin.mockImplementation(() => Promise.resolve());
+    mockSetDestination.mockImplementation(() => Promise.resolve());
+    mockSetFlightDuration.mockImplementation(() => Promise.resolve());
   });
 
   it('continues to the destination step after selecting a flight window', async () => {

--- a/__tests__/screens/FlightSetupScreen.test.tsx
+++ b/__tests__/screens/FlightSetupScreen.test.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 
 import FlightSetupScreen from '@/screens/FlightSetupScreen';
-import { loadAirports } from '@/services/airportService';
-import { getDestinationsInTimeBucket, getDestinationsInTimeRange, getFlightTimeBucket } from '@/services/radiusService';
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockSetOrigin = jest.fn();
+const mockSetDestination = jest.fn();
+const mockSetFlightDuration = jest.fn();
 
 jest.mock('react-native', () => {
   type HostProps = React.PropsWithChildren<Record<string, unknown>>;
@@ -27,72 +31,22 @@ jest.mock('react-native', () => {
   };
 });
 
-jest.mock('@/components/airport/AirportCard', () => ({
-  AirportCard: ({ airport }: { airport: { icao: string } }) => {
-    return React.createElement('Text', { testID: 'home-airport' }, airport.icao);
-  },
-}));
-
-jest.mock('@/components/destinations/DestinationsList', () => ({
-  DestinationsList: ({
-    destinations,
-    isLoading,
-    error,
-    contentBottomInset,
-    headerSubtitle,
-  }: {
-    destinations: Array<{ city: string }>;
-    isLoading: boolean;
-    error: string | null;
-    contentBottomInset?: number;
-    headerSubtitle?: string;
-  }) => {
-    if (isLoading) {
-      return React.createElement('Text', { testID: 'destinations-state' }, 'loading');
-    }
-    if (error) {
-      return React.createElement('Text', { testID: 'destinations-state' }, error);
-    }
-
-    return React.createElement(
-      'View',
-      null,
-      React.createElement(
-        'Text',
-        { testID: 'destinations-state' },
-        destinations.map((destination) => destination.city).join(',')
-      ),
-      React.createElement(
-        'Text',
-        { testID: 'destinations-meta' },
-        `${headerSubtitle ?? ''}|${contentBottomInset ?? 0}`
-      )
-    );
-  },
-}));
-
 jest.mock('@/components/time-slider/TimeSlider', () => ({
-  TimeSlider: ({ onValueChange }: { onValueChange: (value: number) => void }) => {
+  TimeSlider: ({ value, onValueChange }: { value: number; onValueChange: (value: number) => void }) => {
     return React.createElement(
       'Pressable',
       {
         testID: 'mock-time-slider',
-        onPress: () => onValueChange(4200),
+        onPress: () => onValueChange(value + 600),
       },
       React.createElement('Text', null, 'Mock Slider')
     );
   },
 }));
 
-jest.mock('@/components/time-slider/TimeValue', () => ({
-  TimeValue: ({ seconds }: { seconds: number }) => {
-    return React.createElement('Text', { testID: 'time-value' }, String(seconds));
-  },
-}));
-
 jest.mock('@/components/themed-text', () => ({
-  ThemedText: ({ children }: { children: React.ReactNode }) => {
-    return React.createElement('Text', null, children);
+  ThemedText: ({ children, testID, style }: { children: React.ReactNode; testID?: string; style?: unknown }) => {
+    return React.createElement('Text', { testID, style }, children);
   },
 }));
 
@@ -103,15 +57,31 @@ jest.mock('@/components/themed-view', () => ({
 }));
 
 jest.mock('@/components/ui/Button', () => ({
-  Button: ({ title }: { title: string }) => {
-    return React.createElement('Text', { testID: 'review-flight-button' }, title);
+  Button: ({
+    title,
+    onPress,
+    testID,
+    disabled,
+  }: {
+    title: string;
+    onPress: () => void;
+    testID?: string;
+    disabled?: boolean;
+  }) => {
+    return React.createElement(
+      'Pressable',
+      {
+        testID,
+        onPress,
+        disabled,
+      },
+      React.createElement('Text', null, title)
+    );
   },
 }));
 
 jest.mock('@/components/ui/icon-symbol', () => ({
-  IconSymbol: () => {
-    return React.createElement('Text', { testID: 'icon-symbol' }, 'icon');
-  },
+  IconSymbol: () => React.createElement('Text', { testID: 'icon-symbol' }, 'icon'),
 }));
 
 jest.mock('expo-haptics', () => ({
@@ -126,32 +96,28 @@ jest.mock('react-native-safe-area-context', () => ({
   SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => {
     return React.createElement('SafeAreaView', props, children);
   },
-  useSafeAreaInsets: () => ({
-    top: 0,
-    right: 0,
-    bottom: 20,
-    left: 0,
-  }),
 }));
 
 jest.mock('@/hooks/use-color-scheme', () => ({
   useColorScheme: () => 'light',
 }));
 
+const mockHomeAirport = {
+  icao: 'KOKC',
+  iata: 'OKC',
+  name: 'Will Rogers World Airport',
+  city: 'Oklahoma City',
+  country: 'US',
+  state: 'OK',
+  lat: 35.3931,
+  lon: -97.6007,
+  elevation: 1295,
+  tz: 'America/Chicago',
+};
+
 jest.mock('@/hooks/useHomeAirport', () => ({
   useHomeAirport: () => ({
-    homeAirport: {
-      icao: 'KOKC',
-      iata: 'OKC',
-      name: 'Will Rogers World Airport',
-      city: 'Oklahoma City',
-      country: 'US',
-      state: 'OK',
-      lat: 35.3931,
-      lon: -97.6007,
-      elevation: 1295,
-      tz: 'America/Chicago',
-    },
+    homeAirport: mockHomeAirport,
     isLoading: false,
     handleSelectAirport: jest.fn(),
     handleClearHomeBase: jest.fn(),
@@ -164,148 +130,54 @@ jest.mock('@/context/FlightContext', () => ({
     origin: null,
     destination: null,
     flightDuration: 3600,
-    setOrigin: jest.fn(),
-    setDestination: jest.fn(),
-    setFlightDuration: jest.fn(),
+    setOrigin: mockSetOrigin,
+    setDestination: mockSetDestination,
+    setFlightDuration: mockSetFlightDuration,
   }),
 }));
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({
-    back: jest.fn(),
-    push: jest.fn(),
+    back: mockBack,
+    push: mockPush,
   }),
 }));
-
-jest.mock('@/services/airportService', () => ({
-  loadAirports: jest.fn(),
-}));
-
-jest.mock('@/services/radiusService', () => ({
-  getDestinationsInTimeBucket: jest.fn(),
-  getDestinationsInTimeRange: jest.fn(),
-  getFlightTimeBucket: jest.fn(({ timeInSeconds }: { timeInSeconds: number }) => {
-    if (timeInSeconds <= 1800) {
-      return { minTimeInSeconds: 0, maxTimeInSeconds: 1800 };
-    }
-
-    return {
-      minTimeInSeconds: timeInSeconds - 600,
-      maxTimeInSeconds: timeInSeconds,
-    };
-  }),
-}));
-
-const mockDestinations = [
-  {
-    icao: 'KOUN',
-    iata: 'OUN',
-    name: 'University of Oklahoma Westheimer Airport',
-    city: 'Norman',
-    country: 'US',
-    state: 'OK',
-    lat: 35.2456,
-    lon: -97.4721,
-    elevation: 1162,
-    tz: 'America/Chicago',
-    distance: 20,
-    flightTime: 2400,
-  },
-  {
-    icao: 'KSWO',
-    iata: 'SWO',
-    name: 'Stillwater Regional Airport',
-    city: 'Stillwater',
-    country: 'US',
-    state: 'OK',
-    lat: 36.1612,
-    lon: -97.0857,
-    elevation: 1000,
-    tz: 'America/Chicago',
-    distance: 45,
-    flightTime: 4800,
-  },
-];
 
 type TestRendererInstance = ReturnType<typeof TestRenderer.create>;
 
-function getText(renderer: TestRendererInstance, testID: string) {
-  return renderer.root.findByProps({ testID }).children.join('');
-}
-
 describe('FlightSetupScreen', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
     jest.clearAllMocks();
-    (loadAirports as jest.Mock).mockImplementation(() => Promise.resolve());
-    (getDestinationsInTimeRange as jest.Mock).mockReturnValue([]);
-    (getFlightTimeBucket as jest.Mock).mockImplementation(({ timeInSeconds }: { timeInSeconds: number }) => {
-      if (timeInSeconds <= 1800) {
-        return { minTimeInSeconds: 0, maxTimeInSeconds: 1800 };
-      }
-
-      return {
-        minTimeInSeconds: timeInSeconds - 600,
-        maxTimeInSeconds: timeInSeconds,
-      };
-    });
-    (getDestinationsInTimeBucket as jest.Mock).mockImplementation(
-      ({ timeInSeconds }: { timeInSeconds: number }) => {
-        return timeInSeconds >= 4200 ? mockDestinations : mockDestinations.slice(0, 1);
-      }
-    );
+    mockSetOrigin.mockResolvedValue(undefined);
+    mockSetDestination.mockResolvedValue(undefined);
+    mockSetFlightDuration.mockResolvedValue(undefined);
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  it('updates the available destinations after the slider changes', async () => {
+  it('continues to the destination step after selecting a flight window', async () => {
     let renderer: TestRendererInstance | null = null;
 
     act(() => {
       renderer = TestRenderer.create(<FlightSetupScreen />);
     });
 
-    act(() => {
-      jest.advanceTimersByTime(300);
-    });
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
     if (!renderer) {
       throw new Error('Screen renderer not initialized');
     }
 
-    expect(getText(renderer, 'destinations-state')).toBe('Norman');
-    expect(getText(renderer, 'destinations-meta')).toContain('50m - 1h 0m');
+    expect(mockSetOrigin).toHaveBeenCalledWith(mockHomeAirport);
 
     act(() => {
       renderer.root.findByProps({ testID: 'mock-time-slider' }).props.onPress();
     });
 
-    act(() => {
-      jest.advanceTimersByTime(300);
-    });
+    expect(mockSetFlightDuration).toHaveBeenCalledWith(4200);
+    expect(mockSetDestination).toHaveBeenCalledWith(null);
 
     await act(async () => {
+      renderer.root.findByProps({ testID: 'continue-to-destinations' }).props.onPress();
       await Promise.resolve();
     });
 
-    if (!renderer) {
-      throw new Error('Screen renderer not initialized');
-    }
-
-    expect(getText(renderer, 'destinations-state')).toBe('Norman,Stillwater');
-    expect(getText(renderer, 'destinations-meta')).toContain('1h 0m - 1h 10m');
-    expect(getText(renderer, 'destinations-meta')).toContain('|32');
-    expect(getDestinationsInTimeBucket).toHaveBeenCalledWith({
-      origin: { lat: 35.3931, lon: -97.6007 },
-      timeInSeconds: 4200,
-      bucketSizeInSeconds: 600,
-      initialBucketMaxTime: 1800,
-    });
+    expect(mockPush).toHaveBeenCalledWith('/flight/destination');
   });
 });

--- a/app/flight/destination.tsx
+++ b/app/flight/destination.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import FlightDestinationScreen from '@/screens/FlightDestinationScreen';
+import { Stack } from 'expo-router';
+
+export default function FlightDestinationRoute() {
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: false,
+          presentation: 'modal',
+        }}
+      />
+      <FlightDestinationScreen />
+    </>
+  );
+}

--- a/screens/FlightDestinationScreen.tsx
+++ b/screens/FlightDestinationScreen.tsx
@@ -1,0 +1,299 @@
+import { DestinationsList } from '@/components/destinations/DestinationsList';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Button } from '@/components/ui/Button';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { BorderRadius, Colors, Spacing, Typography } from '@/constants/theme';
+import { useFlight } from '@/context/FlightContext';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useDestinations } from '@/hooks/useDestinations';
+import type { AirportWithFlightTime } from '@/types/radius';
+import { formatFlightWindowLabel } from '@/utils/flightWindow';
+import { TIME_SLIDER_CONFIG } from '@/utils/timeSlider';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { useRouter } from 'expo-router';
+import { useCallback, useMemo, useState } from 'react';
+import { LayoutChangeEvent, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.sm,
+  },
+  headerButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
+  },
+  body: {
+    flex: 1,
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing.sm,
+    gap: Spacing.md,
+  },
+  summaryCard: {
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.md,
+    gap: Spacing.sm,
+  },
+  summaryTopRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: Spacing.sm,
+  },
+  label: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.semibold,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  bucketPill: {
+    borderRadius: BorderRadius.full,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 6,
+  },
+  bucketText: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.semibold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  summaryCodeRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: Spacing.sm,
+  },
+  airportCode: {
+    fontSize: Typography.fontSize.xxl,
+    fontWeight: Typography.fontWeight.bold,
+  },
+  airportIata: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+  },
+  airportMeta: {
+    fontSize: Typography.fontSize.sm,
+  },
+  destinationsShell: {
+    flex: 1,
+    minHeight: 0,
+    borderRadius: BorderRadius.lg,
+    overflow: 'hidden',
+    borderWidth: 1,
+  },
+  footer: {
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.sm,
+    shadowColor: '#0f172a',
+    shadowOffset: { width: 0, height: -6 },
+    shadowOpacity: 0.08,
+    shadowRadius: 16,
+    elevation: 10,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.sm,
+  },
+});
+
+export default function FlightDestinationScreen() {
+  const router = useRouter();
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'light'];
+  const insets = useSafeAreaInsets();
+  const { origin, destination, flightDuration, setDestination } = useFlight();
+  const [footerHeight, setFooterHeight] = useState(0);
+
+  const bucketLabel = useMemo(() => formatFlightWindowLabel(flightDuration), [flightDuration]);
+  const {
+    destinations,
+    isLoading,
+    error,
+  } = useDestinations({
+    origin,
+    flightTimeInSeconds: flightDuration,
+    useTimeRange: false,
+    bucketIntervalSeconds: TIME_SLIDER_CONFIG.SNAP_INTERVAL,
+    initialBucketMaxTime: TIME_SLIDER_CONFIG.MIN_TIME,
+  });
+
+  const selectedDestinationWithTime = useMemo(() => {
+    if (!destination) {
+      return null;
+    }
+
+    return destinations.find((currentDestination) => currentDestination.icao === destination.icao) ?? null;
+  }, [destination, destinations]);
+
+  const footerInset = footerHeight + Spacing.xl;
+
+  const handleBack = useCallback(() => {
+    impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
+    router.back();
+  }, [router]);
+
+  const handleSelectDestination = useCallback(
+    (airport: AirportWithFlightTime) => {
+      setDestination(airport).catch(() => undefined);
+    },
+    [setDestination]
+  );
+
+  const handleReviewFlight = useCallback(() => {
+    if (!selectedDestinationWithTime) {
+      return;
+    }
+
+    impactAsync(ImpactFeedbackStyle.Heavy).catch(() => undefined);
+    router.push('/flight/review');
+  }, [router, selectedDestinationWithTime]);
+
+  const handleFooterLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = event.nativeEvent.layout.height;
+    setFooterHeight((currentHeight) => {
+      return currentHeight === nextHeight ? currentHeight : nextHeight;
+    });
+  }, []);
+
+  if (!origin) {
+    return (
+      <ThemedView style={styles.container}>
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.header}>
+            <TouchableOpacity
+              onPress={handleBack}
+              style={[styles.headerButton, { backgroundColor: colors.cardBackground }]}
+              accessibilityLabel="Back to flight setup"
+              accessibilityRole="button"
+            >
+              <IconSymbol name="chevron.left" size={20} color={colors.text} />
+            </TouchableOpacity>
+            <ThemedText style={styles.headerTitle}>Choose Destination</ThemedText>
+            <View style={styles.headerButton} />
+          </View>
+          <View style={styles.emptyState}>
+            <ThemedText type="subtitle">No departure selected</ThemedText>
+            <ThemedText style={{ color: colors.textSecondary, textAlign: 'center' }}>
+              Go back and choose your departure airport and flight window first.
+            </ThemedText>
+          </View>
+        </SafeAreaView>
+      </ThemedView>
+    );
+  }
+
+  return (
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            onPress={handleBack}
+            style={[styles.headerButton, { backgroundColor: colors.cardBackground }]}
+            accessibilityLabel="Back to flight setup"
+            accessibilityRole="button"
+            testID="back-to-flight-setup"
+          >
+            <IconSymbol name="chevron.left" size={20} color={colors.text} />
+          </TouchableOpacity>
+          <ThemedText style={styles.headerTitle}>Choose Destination</ThemedText>
+          <View style={styles.headerButton} />
+        </View>
+
+        <View style={styles.body}>
+          <View
+            style={[
+              styles.summaryCard,
+              { backgroundColor: colors.cardBackground, borderColor: colors.border },
+            ]}
+          >
+            <View style={styles.summaryTopRow}>
+              <ThemedText style={[styles.label, { color: colors.textSecondary }]}>
+                Departing From
+              </ThemedText>
+              <View style={[styles.bucketPill, { backgroundColor: colors.surfaceElevated }]}>
+                <ThemedText style={[styles.bucketText, { color: colors.primary }]} testID="destination-summary-bucket">
+                  {bucketLabel}
+                </ThemedText>
+              </View>
+            </View>
+
+            <View style={styles.summaryCodeRow}>
+              <ThemedText style={styles.airportCode} testID="destination-summary-airport">
+                {origin.icao}
+              </ThemedText>
+              {origin.iata ? (
+                <ThemedText style={[styles.airportIata, { color: colors.primary }]}>
+                  {origin.iata}
+                </ThemedText>
+              ) : null}
+            </View>
+
+            <ThemedText style={styles.airportMeta}>{origin.name}</ThemedText>
+            <ThemedText style={[styles.airportMeta, { color: colors.textSecondary }]}>
+              {origin.state ? `${origin.city}, ${origin.state}` : origin.city}
+            </ThemedText>
+          </View>
+
+          <View
+            style={[
+              styles.destinationsShell,
+              { backgroundColor: colors.cardBackground, borderColor: colors.border },
+            ]}
+          >
+            <DestinationsList
+              destinations={destinations}
+              selectedDestination={selectedDestinationWithTime}
+              onSelectDestination={handleSelectDestination}
+              isLoading={isLoading}
+              error={error}
+              compactCards
+              contentBottomInset={footerInset}
+              testID="destination-list"
+            />
+          </View>
+        </View>
+
+        <View
+          onLayout={handleFooterLayout}
+          style={[
+            styles.footer,
+            {
+              backgroundColor: colors.background,
+              paddingBottom: Math.max(insets.bottom, Spacing.md),
+            },
+          ]}
+        >
+          <Button
+            title="Review Flight"
+            onPress={handleReviewFlight}
+            disabled={!selectedDestinationWithTime}
+            testID="review-flight-button"
+          />
+        </View>
+      </SafeAreaView>
+    </ThemedView>
+  );
+}

--- a/screens/FlightDestinationScreen.tsx
+++ b/screens/FlightDestinationScreen.tsx
@@ -179,83 +179,16 @@ export default function FlightDestinationScreen() {
   }, []);
 
   if (!origin) {
-    return (
-      <ThemedView style={styles.container}>
-        <SafeAreaView style={styles.safeArea}>
-          <View style={styles.header}>
-            <TouchableOpacity
-              onPress={handleBack}
-              style={[styles.headerButton, { backgroundColor: colors.cardBackground }]}
-              accessibilityLabel="Back to flight setup"
-              accessibilityRole="button"
-            >
-              <IconSymbol name="chevron.left" size={20} color={colors.text} />
-            </TouchableOpacity>
-            <ThemedText style={styles.headerTitle}>Choose Destination</ThemedText>
-            <View style={styles.headerButton} />
-          </View>
-          <View style={styles.emptyState}>
-            <ThemedText type="subtitle">No departure selected</ThemedText>
-            <ThemedText style={{ color: colors.textSecondary, textAlign: 'center' }}>
-              Go back and choose your departure airport and flight window first.
-            </ThemedText>
-          </View>
-        </SafeAreaView>
-      </ThemedView>
-    );
+    return <MissingOriginState onBack={handleBack} colors={colors} />;
   }
 
   return (
     <ThemedView style={styles.container}>
       <SafeAreaView style={styles.safeArea}>
-        <View style={styles.header}>
-          <TouchableOpacity
-            onPress={handleBack}
-            style={[styles.headerButton, { backgroundColor: colors.cardBackground }]}
-            accessibilityLabel="Back to flight setup"
-            accessibilityRole="button"
-            testID="back-to-flight-setup"
-          >
-            <IconSymbol name="chevron.left" size={20} color={colors.text} />
-          </TouchableOpacity>
-          <ThemedText style={styles.headerTitle}>Choose Destination</ThemedText>
-          <View style={styles.headerButton} />
-        </View>
+        <DestinationStepHeader onBack={handleBack} colors={colors} />
 
         <View style={styles.body}>
-          <View
-            style={[
-              styles.summaryCard,
-              { backgroundColor: colors.cardBackground, borderColor: colors.border },
-            ]}
-          >
-            <View style={styles.summaryTopRow}>
-              <ThemedText style={[styles.label, { color: colors.textSecondary }]}>
-                Departing From
-              </ThemedText>
-              <View style={[styles.bucketPill, { backgroundColor: colors.surfaceElevated }]}>
-                <ThemedText style={[styles.bucketText, { color: colors.primary }]} testID="destination-summary-bucket">
-                  {bucketLabel}
-                </ThemedText>
-              </View>
-            </View>
-
-            <View style={styles.summaryCodeRow}>
-              <ThemedText style={styles.airportCode} testID="destination-summary-airport">
-                {origin.icao}
-              </ThemedText>
-              {origin.iata ? (
-                <ThemedText style={[styles.airportIata, { color: colors.primary }]}>
-                  {origin.iata}
-                </ThemedText>
-              ) : null}
-            </View>
-
-            <ThemedText style={styles.airportMeta}>{origin.name}</ThemedText>
-            <ThemedText style={[styles.airportMeta, { color: colors.textSecondary }]}>
-              {origin.state ? `${origin.city}, ${origin.state}` : origin.city}
-            </ThemedText>
-          </View>
+          <DestinationSummaryCard origin={origin} bucketLabel={bucketLabel} colors={colors} />
 
           <View
             style={[
@@ -276,22 +209,142 @@ export default function FlightDestinationScreen() {
           </View>
         </View>
 
-        <View
+        <DestinationReviewFooter
           onLayout={handleFooterLayout}
-          style={[
-            styles.footer,
-            {
-              backgroundColor: colors.background,
-              paddingBottom: Math.max(insets.bottom, Spacing.md),
-            },
-          ]}
-        >
-          <Button
-            title="Review Flight"
-            onPress={handleReviewFlight}
-            disabled={!selectedDestinationWithTime}
-            testID="review-flight-button"
-          />
+          onReview={handleReviewFlight}
+          disabled={!selectedDestinationWithTime}
+          bottomInset={Math.max(insets.bottom, Spacing.md)}
+          backgroundColor={colors.background}
+        />
+      </SafeAreaView>
+    </ThemedView>
+  );
+}
+
+function DestinationStepHeader({
+  onBack,
+  colors,
+}: {
+  onBack: () => void;
+  colors: typeof Colors.light;
+}) {
+  return (
+    <View style={styles.header}>
+      <TouchableOpacity
+        onPress={onBack}
+        style={[styles.headerButton, { backgroundColor: colors.cardBackground }]}
+        accessibilityLabel="Back to flight setup"
+        accessibilityRole="button"
+        testID="back-to-flight-setup"
+        hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
+      >
+        <IconSymbol name="chevron.left" size={20} color={colors.text} />
+      </TouchableOpacity>
+      <ThemedText style={styles.headerTitle}>Choose Destination</ThemedText>
+      <View style={styles.headerButton} />
+    </View>
+  );
+}
+
+function DestinationSummaryCard({
+  origin,
+  bucketLabel,
+  colors,
+}: {
+  origin: NonNullable<ReturnType<typeof useFlight>['origin']>;
+  bucketLabel: string;
+  colors: typeof Colors.light;
+}) {
+  return (
+    <View
+      style={[
+        styles.summaryCard,
+        { backgroundColor: colors.cardBackground, borderColor: colors.border },
+      ]}
+    >
+      <View style={styles.summaryTopRow}>
+        <ThemedText style={[styles.label, { color: colors.textSecondary }]}>
+          Departing From
+        </ThemedText>
+        <View style={[styles.bucketPill, { backgroundColor: colors.surfaceElevated }]}>
+          <ThemedText
+            style={[styles.bucketText, { color: colors.primary }]}
+            testID="destination-summary-bucket"
+          >
+            {bucketLabel}
+          </ThemedText>
+        </View>
+      </View>
+
+      <View style={styles.summaryCodeRow}>
+        <ThemedText style={styles.airportCode} testID="destination-summary-airport">
+          {origin.icao}
+        </ThemedText>
+        {origin.iata ? (
+          <ThemedText style={[styles.airportIata, { color: colors.primary }]}>
+            {origin.iata}
+          </ThemedText>
+        ) : null}
+      </View>
+
+      <ThemedText style={styles.airportMeta}>{origin.name}</ThemedText>
+      <ThemedText style={[styles.airportMeta, { color: colors.textSecondary }]}>
+        {origin.state ? `${origin.city}, ${origin.state}` : origin.city}
+      </ThemedText>
+    </View>
+  );
+}
+
+function DestinationReviewFooter({
+  onLayout,
+  onReview,
+  disabled,
+  bottomInset,
+  backgroundColor,
+}: {
+  onLayout: (event: LayoutChangeEvent) => void;
+  onReview: () => void;
+  disabled: boolean;
+  bottomInset: number;
+  backgroundColor: string;
+}) {
+  return (
+    <View
+      onLayout={onLayout}
+      style={[
+        styles.footer,
+        {
+          backgroundColor,
+          paddingBottom: bottomInset,
+        },
+      ]}
+    >
+      <Button
+        title="Review Flight"
+        onPress={onReview}
+        disabled={disabled}
+        testID="review-flight-button"
+      />
+    </View>
+  );
+}
+
+function MissingOriginState({
+  onBack,
+  colors,
+}: {
+  onBack: () => void;
+  colors: typeof Colors.light;
+}) {
+  return (
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.safeArea}>
+        <DestinationStepHeader onBack={onBack} colors={colors} />
+        <View style={styles.emptyState}>
+          <ThemedText type="subtitle">No departure selected</ThemedText>
+          <ThemedText style={{ color: colors.textSecondary, textAlign: 'center' }}>
+            Go back and choose your departure airport and flight window first.
+          </ThemedText>
         </View>
       </SafeAreaView>
     </ThemedView>

--- a/screens/FlightSetupScreen.tsx
+++ b/screens/FlightSetupScreen.tsx
@@ -135,6 +135,10 @@ export default function FlightSetupScreen() {
     }
   }, [homeAirport, origin, setOrigin]);
 
+  useEffect(() => {
+    setLocalFlightTime(flightDuration);
+  }, [flightDuration]);
+
   const bucketLabel = useMemo(() => formatFlightWindowLabel(localFlightTime), [localFlightTime]);
   const formattedDuration = useMemo(
     () => formatTimeValue(localFlightTime).formatted,
@@ -158,7 +162,6 @@ export default function FlightSetupScreen() {
     await Promise.all([
       setOrigin(homeAirport),
       setFlightDuration(localFlightTime),
-      setDestination(null),
     ]);
 
     await impactAsync(ImpactFeedbackStyle.Heavy).catch(() => undefined);
@@ -181,6 +184,7 @@ export default function FlightSetupScreen() {
             accessibilityLabel="Close flight setup"
             accessibilityRole="button"
             testID="close-flight-setup"
+            hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
           >
             <IconSymbol name="xmark" size={20} color={colors.text} />
           </TouchableOpacity>

--- a/screens/FlightSetupScreen.tsx
+++ b/screens/FlightSetupScreen.tsx
@@ -1,25 +1,20 @@
-import { DestinationsList } from '@/components/destinations/DestinationsList';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { TimeSlider } from '@/components/time-slider/TimeSlider';
-import { TimeValue } from '@/components/time-slider/TimeValue';
 import { Button } from '@/components/ui/Button';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { BorderRadius, Colors, Spacing, Typography } from '@/constants/theme';
 import { useFlight } from '@/context/FlightContext';
 import { useColorScheme } from '@/hooks/use-color-scheme';
-import { useDestinations } from '@/hooks/useDestinations';
 import { useHomeAirport } from '@/hooks/useHomeAirport';
-import { getFlightTimeBucket } from '@/services/radiusService';
 import type { Airport } from '@/types/airport';
-import type { AirportWithFlightTime } from '@/types/radius';
-import { formatTimeValue, TIME_SLIDER_CONFIG } from '@/utils/timeSlider';
+import { formatFlightWindowLabel } from '@/utils/flightWindow';
+import { formatTimeValue } from '@/utils/timeSlider';
 import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import { useRouter } from 'expo-router';
-import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { LayoutChangeEvent, StyleSheet, TouchableOpacity, View } from 'react-native';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 const styles = StyleSheet.create({
   container: {
@@ -33,125 +28,188 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingHorizontal: Spacing.lg,
-    paddingTop: Spacing.xs,
+    paddingTop: Spacing.sm,
     paddingBottom: Spacing.md,
   },
+  title: {
+    fontSize: Typography.fontSize.xxl,
+    fontWeight: Typography.fontWeight.bold,
+  },
   closeButton: {
-    width: 42,
-    height: 42,
-    borderRadius: 21,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
     alignItems: 'center',
     justifyContent: 'center',
   },
   body: {
     flex: 1,
     paddingHorizontal: Spacing.lg,
-    paddingBottom: Spacing.sm,
     gap: Spacing.md,
   },
-  topStack: {
-    gap: Spacing.md,
-  },
-  panel: {
+  card: {
     borderRadius: BorderRadius.lg,
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.md,
     borderWidth: 1,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.md,
   },
-  panelHeader: {
+  cardHeader: {
     flexDirection: 'row',
+    alignItems: 'flex-start',
     justifyContent: 'space-between',
-    alignItems: 'center',
     marginBottom: Spacing.sm,
+    gap: Spacing.sm,
   },
-  panelLabel: {
+  label: {
     fontSize: Typography.fontSize.xs,
     fontWeight: Typography.fontWeight.semibold,
-    textTransform: 'uppercase',
     letterSpacing: 1,
+    textTransform: 'uppercase',
   },
-  originCodeRow: {
+  helperText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  codeRow: {
     flexDirection: 'row',
     alignItems: 'baseline',
     gap: Spacing.sm,
   },
-  originIata: {
-    fontSize: Typography.fontSize.sm,
+  airportCode: {
+    fontSize: Typography.fontSize.xxxl,
+    fontWeight: Typography.fontWeight.bold,
+  },
+  iataCode: {
+    fontSize: Typography.fontSize.base,
     fontWeight: Typography.fontWeight.semibold,
   },
-  originName: {
-    fontSize: Typography.fontSize.sm,
-    marginTop: 4,
-  },
-  originMeta: {
-    fontSize: Typography.fontSize.sm,
+  airportName: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.medium,
     marginTop: Spacing.xs,
   },
-  sliderPanelTop: {
-    marginBottom: Spacing.sm,
+  airportMeta: {
+    fontSize: Typography.fontSize.sm,
+    marginTop: 2,
   },
-  sliderValueRow: {
+  windowValueRow: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: Spacing.xs,
+    justifyContent: 'space-between',
+    marginBottom: Spacing.sm,
+    gap: Spacing.sm,
+  },
+  windowValue: {
+    fontSize: Typography.fontSize.xxxl,
+    fontWeight: Typography.fontWeight.bold,
   },
   bucketPill: {
-    alignSelf: 'flex-start',
-    borderRadius: 999,
+    borderRadius: BorderRadius.full,
     paddingHorizontal: Spacing.sm,
     paddingVertical: 6,
   },
-  bucketPillText: {
+  bucketText: {
     fontSize: Typography.fontSize.xs,
     fontWeight: Typography.fontWeight.semibold,
     textTransform: 'uppercase',
     letterSpacing: 0.6,
   },
-  destinationsShell: {
-    flex: 1,
-    minHeight: 0,
-    borderRadius: BorderRadius.lg,
-    overflow: 'hidden',
-    borderWidth: 1,
-  },
   footer: {
     paddingHorizontal: Spacing.lg,
-    paddingTop: Spacing.sm,
-    shadowColor: '#0f172a',
-    shadowOffset: { width: 0, height: -6 },
-    shadowOpacity: 0.08,
-    shadowRadius: 16,
-    elevation: 10,
+    paddingTop: Spacing.md,
+    paddingBottom: Spacing.xl,
   },
 });
 
-function FlightSetupHeader({ onClose }: { onClose: () => void }) {
+export default function FlightSetupScreen() {
+  const { homeAirport } = useHomeAirport();
+  const { origin, flightDuration, setOrigin, setDestination, setFlightDuration } = useFlight();
+  const router = useRouter();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const [localFlightTime, setLocalFlightTime] = useState(flightDuration);
+
+  useEffect(() => {
+    if (homeAirport && (!origin || origin.icao !== homeAirport.icao)) {
+      setOrigin(homeAirport).catch(() => undefined);
+    }
+  }, [homeAirport, origin, setOrigin]);
+
+  const bucketLabel = useMemo(() => formatFlightWindowLabel(localFlightTime), [localFlightTime]);
+  const formattedDuration = useMemo(
+    () => formatTimeValue(localFlightTime).formatted,
+    [localFlightTime]
+  );
+
+  const handleFlightTimeChange = useCallback(
+    (time: number) => {
+      setLocalFlightTime(time);
+      setFlightDuration(time).catch(() => undefined);
+      setDestination(null).catch(() => undefined);
+    },
+    [setDestination, setFlightDuration]
+  );
+
+  const handleContinue = useCallback(async () => {
+    if (!homeAirport) {
+      return;
+    }
+
+    await Promise.all([
+      setOrigin(homeAirport),
+      setFlightDuration(localFlightTime),
+      setDestination(null),
+    ]);
+
+    await impactAsync(ImpactFeedbackStyle.Heavy).catch(() => undefined);
+    router.push('/flight/destination');
+  }, [homeAirport, localFlightTime, router, setDestination, setFlightDuration, setOrigin]);
+
+  const handleClose = useCallback(() => {
+    impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
+    router.back();
+  }, [router]);
 
   return (
-    <View style={styles.header}>
-      <View>
-        <ThemedText type="title">Flight Setup</ThemedText>
-        <ThemedText style={{ color: colors.textSecondary }}>
-          Pick a flight window, then choose a destination.
-        </ThemedText>
-      </View>
-      <TouchableOpacity
-        onPress={onClose}
-        style={[styles.closeButton, { backgroundColor: colors.cardBackground }]}
-        accessibilityLabel="Close flight setup"
-        accessibilityRole="button"
-        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-      >
-        <IconSymbol name="xmark" size={20} color={colors.text} />
-      </TouchableOpacity>
-    </View>
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.header}>
+          <ThemedText style={styles.title}>Flight Setup</ThemedText>
+          <TouchableOpacity
+            onPress={handleClose}
+            style={[styles.closeButton, { backgroundColor: colors.cardBackground }]}
+            accessibilityLabel="Close flight setup"
+            accessibilityRole="button"
+            testID="close-flight-setup"
+          >
+            <IconSymbol name="xmark" size={20} color={colors.text} />
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.body}>
+          <DepartureCard airport={homeAirport} />
+          <FlightWindowCard
+            flightTime={localFlightTime}
+            flightTimeLabel={formattedDuration}
+            bucketLabel={bucketLabel}
+            onFlightTimeChange={handleFlightTimeChange}
+          />
+        </View>
+
+        <View style={styles.footer}>
+          <Button
+            title="Continue"
+            onPress={handleContinue}
+            disabled={!homeAirport}
+            testID="continue-to-destinations"
+          />
+        </View>
+      </SafeAreaView>
+    </ThemedView>
   );
 }
 
-function OriginSummaryCard({ airport }: { airport: Airport | null }) {
+function DepartureCard({ airport }: { airport: Airport | null }) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
 
@@ -159,14 +217,11 @@ function OriginSummaryCard({ airport }: { airport: Airport | null }) {
     return (
       <View
         style={[
-          styles.panel,
-          {
-            backgroundColor: colors.cardBackground,
-            borderColor: colors.border,
-          },
+          styles.card,
+          { backgroundColor: colors.cardBackground, borderColor: colors.border },
         ]}
       >
-        <ThemedText style={[styles.panelLabel, { color: colors.textSecondary }]}>
+        <ThemedText style={[styles.label, { color: colors.textSecondary }]}>
           Departure
         </ThemedText>
         <ThemedText>No home base selected</ThemedText>
@@ -177,259 +232,76 @@ function OriginSummaryCard({ airport }: { airport: Airport | null }) {
   return (
     <View
       style={[
-        styles.panel,
-        {
-          backgroundColor: colors.cardBackground,
-          borderColor: colors.border,
-        },
+        styles.card,
+        { backgroundColor: colors.cardBackground, borderColor: colors.border },
       ]}
     >
-      <View style={styles.panelHeader}>
-        <ThemedText style={[styles.panelLabel, { color: colors.textSecondary }]}>
+      <View style={styles.cardHeader}>
+        <ThemedText style={[styles.label, { color: colors.textSecondary }]}>
           Departure
         </ThemedText>
-        <ThemedText style={[styles.originIata, { color: colors.textSecondary }]}>
+        <ThemedText style={[styles.helperText, { color: colors.textSecondary }]}>
           {airport.city}
         </ThemedText>
       </View>
-      <View style={styles.originCodeRow}>
-        <ThemedText type="title">{airport.icao}</ThemedText>
-        {Boolean(airport.iata) && (
-          <ThemedText style={[styles.originIata, { color: colors.primary }]}>
+
+      <View style={styles.codeRow}>
+        <ThemedText style={styles.airportCode}>{airport.icao}</ThemedText>
+        {airport.iata ? (
+          <ThemedText style={[styles.iataCode, { color: colors.primary }]}>
             {airport.iata}
           </ThemedText>
-        )}
+        ) : null}
       </View>
-      <ThemedText style={styles.originName}>{airport.name}</ThemedText>
-      <ThemedText style={[styles.originMeta, { color: colors.textSecondary }]}>
+
+      <ThemedText style={styles.airportName}>{airport.name}</ThemedText>
+      <ThemedText style={[styles.airportMeta, { color: colors.textSecondary }]}>
         {airport.state ? `${airport.city}, ${airport.state}` : airport.city}
       </ThemedText>
     </View>
   );
 }
 
-function FlightTimeCard({
+function FlightWindowCard({
   flightTime,
-  onFlightTimeChange,
+  flightTimeLabel,
   bucketLabel,
+  onFlightTimeChange,
 }: {
   flightTime: number;
-  onFlightTimeChange: (time: number) => void;
+  flightTimeLabel: string;
   bucketLabel: string;
+  onFlightTimeChange: (time: number) => void;
 }) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
-  const bucketPill = (
-    <View style={[styles.bucketPill, { backgroundColor: colors.surfaceElevated }]}>
-      <ThemedText style={[styles.bucketPillText, { color: colors.primary }]}>
-        {bucketLabel}
-      </ThemedText>
-    </View>
-  );
 
   return (
     <View
       style={[
-        styles.panel,
-        {
-          backgroundColor: colors.cardBackground,
-          borderColor: colors.border,
-        },
+        styles.card,
+        { backgroundColor: colors.cardBackground, borderColor: colors.border },
       ]}
     >
-      <View style={styles.sliderPanelTop}>
-        <FlightTimeCardHeader bucketPill={bucketPill} textSecondary={colors.textSecondary} />
-        <TimeValue seconds={flightTime} />
-      </View>
-      <TimeSlider value={flightTime} onValueChange={onFlightTimeChange} />
-    </View>
-  );
-}
-
-function FlightSetupFooter({
-  onStart,
-  isDisabled,
-  onLayout,
-}: {
-  onStart: () => void;
-  isDisabled: boolean;
-  onLayout: (event: LayoutChangeEvent) => void;
-}) {
-  const colorScheme = useColorScheme();
-  const colors = Colors[colorScheme ?? 'light'];
-  const insets = useSafeAreaInsets();
-
-  return (
-    <View
-      onLayout={onLayout}
-      style={[
-        styles.footer,
-        {
-          backgroundColor: colors.background,
-          paddingBottom: Math.max(insets.bottom, Spacing.md),
-        },
-      ]}
-    >
-      <Button
-        title="Review Flight"
-        onPress={onStart}
-        size="md"
-        disabled={isDisabled}
-        testID="review-flight-button"
-      />
-    </View>
-  );
-}
-
-function formatBucketLabel(flightTime: number): string {
-  const bucket = getFlightTimeBucket({
-    timeInSeconds: flightTime,
-    bucketSizeInSeconds: TIME_SLIDER_CONFIG.SNAP_INTERVAL,
-    initialBucketMaxTime: TIME_SLIDER_CONFIG.MIN_TIME,
-  });
-  const maxLabel = formatTimeValue(bucket.maxTimeInSeconds).formatted;
-
-  if (bucket.minTimeInSeconds === 0) {
-    return `Up to ${maxLabel}`;
-  }
-
-  const minLabel = formatTimeValue(bucket.minTimeInSeconds).formatted;
-  return `${minLabel} - ${maxLabel}`;
-}
-
-export default function FlightSetupScreen() {
-  const { homeAirport } = useHomeAirport();
-  const router = useRouter();
-  const colorScheme = useColorScheme();
-  const colors = Colors[colorScheme ?? 'light'];
-  const {
-    origin,
-    destination,
-    flightDuration,
-    setOrigin,
-    setDestination,
-    setFlightDuration,
-  } = useFlight();
-
-  const [localFlightTime, setLocalFlightTime] = useState(flightDuration);
-  const [footerHeight, setFooterHeight] = useState(0);
-
-  useEffect(() => {
-    if (homeAirport && (!origin || origin.icao !== homeAirport.icao)) {
-      setOrigin(homeAirport);
-    }
-  }, [homeAirport, origin, setOrigin]);
-
-  const {
-    destinations,
-    isLoading: isLoadingDestinations,
-    error: destinationsError,
-  } = useDestinations({
-    origin: homeAirport,
-    flightTimeInSeconds: localFlightTime,
-    useTimeRange: false,
-    bucketIntervalSeconds: TIME_SLIDER_CONFIG.SNAP_INTERVAL,
-    initialBucketMaxTime: TIME_SLIDER_CONFIG.MIN_TIME,
-  });
-
-  const selectedDestinationWithTime = destination
-    ? destinations.find((currentDestination) => currentDestination.icao === destination.icao) || null
-    : null;
-
-  const bucketLabel = useMemo(() => formatBucketLabel(localFlightTime), [localFlightTime]);
-  const footerInset = footerHeight + Spacing.xl;
-
-  const handleFlightTimeChange = useCallback((time: number) => {
-    setLocalFlightTime(time);
-    setFlightDuration(time);
-  }, [setFlightDuration]);
-
-  const handleSelectDestination = useCallback(
-    (airport: AirportWithFlightTime) => {
-      setDestination(airport);
-    },
-    [setDestination]
-  );
-
-  const handleReviewFlight = useCallback(() => {
-    if (!destination) return;
-
-    impactAsync(ImpactFeedbackStyle.Heavy).catch(() => undefined);
-    router.push('/flight/review');
-  }, [destination, router]);
-
-  const handleClose = useCallback(() => {
-    impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
-    router.back();
-  }, [router]);
-
-  const handleFooterLayout = useCallback((event: LayoutChangeEvent) => {
-    const nextHeight = event.nativeEvent.layout.height;
-    setFooterHeight((currentHeight) => {
-      return currentHeight === nextHeight ? currentHeight : nextHeight;
-    });
-  }, []);
-
-  return (
-    <ThemedView style={styles.container}>
-      <SafeAreaView style={styles.safeArea}>
-        <FlightSetupHeader onClose={handleClose} />
-        <View style={styles.body}>
-          <View style={styles.topStack}>
-            <OriginSummaryCard airport={homeAirport} />
-            <FlightTimeCard
-              flightTime={localFlightTime}
-              onFlightTimeChange={handleFlightTimeChange}
-              bucketLabel={bucketLabel}
-            />
-          </View>
-
-          <View
-            style={[
-              styles.destinationsShell,
-              {
-                backgroundColor: colors.cardBackground,
-                borderColor: colors.border,
-              },
-            ]}
-          >
-            <DestinationsList
-              destinations={destinations}
-              selectedDestination={selectedDestinationWithTime}
-              onSelectDestination={handleSelectDestination}
-              isLoading={isLoadingDestinations}
-              error={destinationsError}
-              compactCards
-              contentBottomInset={footerInset}
-              headerSubtitle={bucketLabel}
-              testID="destinations-list"
-            />
-          </View>
+      <View style={styles.cardHeader}>
+        <ThemedText style={[styles.label, { color: colors.textSecondary }]}>
+          Flight Window
+        </ThemedText>
+        <View style={[styles.bucketPill, { backgroundColor: colors.surfaceElevated }]}>
+          <ThemedText style={[styles.bucketText, { color: colors.primary }]}>
+            {bucketLabel}
+          </ThemedText>
         </View>
+      </View>
 
-        <FlightSetupFooter
-          onStart={handleReviewFlight}
-          isDisabled={!destination || !homeAirport}
-          onLayout={handleFooterLayout}
-        />
-      </SafeAreaView>
-    </ThemedView>
-  );
-}
+      <View style={styles.windowValueRow}>
+        <ThemedText style={styles.windowValue}>{flightTimeLabel}</ThemedText>
+        <ThemedText style={[styles.helperText, { color: colors.textSecondary }]}>
+          Current duration
+        </ThemedText>
+      </View>
 
-function FlightTimeCardHeader({
-  bucketPill,
-  textSecondary,
-}: {
-  bucketPill: ReactNode;
-  textSecondary: string;
-}) {
-  return (
-    <View style={styles.sliderValueRow}>
-      <ThemedText style={[styles.panelLabel, { color: textSecondary }]}>
-        Flight Window
-      </ThemedText>
-      {bucketPill}
+      <TimeSlider value={flightTime} onValueChange={onFlightTimeChange} />
     </View>
   );
 }

--- a/utils/flightWindow.ts
+++ b/utils/flightWindow.ts
@@ -1,0 +1,18 @@
+import { getFlightTimeBucket } from '@/services/radiusService';
+import { formatTimeValue, TIME_SLIDER_CONFIG } from '@/utils/timeSlider';
+
+export function formatFlightWindowLabel(flightTimeInSeconds: number): string {
+  const bucket = getFlightTimeBucket({
+    timeInSeconds: flightTimeInSeconds,
+    bucketSizeInSeconds: TIME_SLIDER_CONFIG.SNAP_INTERVAL,
+    initialBucketMaxTime: TIME_SLIDER_CONFIG.MIN_TIME,
+  });
+  const maxLabel = formatTimeValue(bucket.maxTimeInSeconds).formatted;
+
+  if (bucket.minTimeInSeconds === 0) {
+    return `Up to ${maxLabel}`;
+  }
+
+  const minLabel = formatTimeValue(bucket.minTimeInSeconds).formatted;
+  return `${minLabel} - ${maxLabel}`;
+}


### PR DESCRIPTION
## Summary
- split Flight Setup into a two-step wizard with a compact setup screen and a dedicated destination picker route
- keep the existing bucketed destination logic while moving destination browsing onto its own screen with a sticky summary
- add screen regression coverage for the new setup-to-destination flow and the review button state

## Testing
- npx tsc --noEmit
- npm test -- --runInBand
- npm run lint
