### PR TITLE
fix: clean up flight headers and cockpit UI

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -60,6 +60,25 @@ export default function RootLayout() {
               name="flight/setup"
               options={{ presentation: "modal", headerShown: false }}
             />
+            <Stack.Screen
+              name="flight/destination"
+              options={{ presentation: "modal", headerShown: false }}
+            />
+            <Stack.Screen name="flight/review" options={{ headerShown: false }} />
+            <Stack.Screen
+              name="flight/seat-selection"
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="flight/booking-confirmation"
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen name="flight/check-in" options={{ headerShown: false }} />
+            <Stack.Screen
+              name="flight/boarding-pass"
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen name="flight/cockpit" options={{ headerShown: false }} />
             <Stack.Screen name="onboarding" options={{ headerShown: false }} />
           </Stack>
           <StatusBar

--- a/components/cockpit/CockpitTabs.tsx
+++ b/components/cockpit/CockpitTabs.tsx
@@ -11,8 +11,8 @@ import { ThemedText } from '@/components/themed-text';
 import { Colors, Spacing, Typography } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
-import { useEffect, useRef } from 'react';
-import { Animated, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Animated, LayoutChangeEvent, StyleSheet, TouchableOpacity, View } from 'react-native';
 
 export type CockpitTab = 'map' | 'metrics' | 'info';
 
@@ -23,11 +23,12 @@ export interface CockpitTabsProps {
   onTabChange: (tab: CockpitTab) => void;
 }
 
-const TABS: Array<{ id: CockpitTab; label: string; icon: string }> = [
+const TABS: { id: CockpitTab; label: string; icon: string }[] = [
   { id: 'map', label: 'Map', icon: '🗺️' },
   { id: 'metrics', label: 'Metrics', icon: '📊' },
   { id: 'info', label: 'Info', icon: 'ℹ️' },
 ];
+const TAB_GAP = Spacing.xs;
 
 const styles = StyleSheet.create({
   container: {
@@ -81,22 +82,34 @@ const styles = StyleSheet.create({
 export function CockpitTabs({ selectedTab, onTabChange }: CockpitTabsProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
-  
-  // Animated indicator position
+  const [tabsWidth, setTabsWidth] = useState(0);
   const indicatorPosition = useRef(new Animated.Value(0)).current;
-  
-  // Calculate indicator position based on selected tab
+  const selectedTabIndex = useMemo(() => {
+    return Math.max(
+      TABS.findIndex((tab) => tab.id === selectedTab),
+      0
+    );
+  }, [selectedTab]);
+  const indicatorWidth = useMemo(() => {
+    if (tabsWidth === 0) {
+      return 0;
+    }
+
+    return (tabsWidth - TAB_GAP * (TABS.length - 1)) / TABS.length;
+  }, [tabsWidth]);
+
   useEffect(() => {
-    const tabIndex = TABS.findIndex(tab => tab.id === selectedTab);
-    const position = tabIndex / TABS.length;
-    
     Animated.spring(indicatorPosition, {
-      toValue: position,
+      toValue: selectedTabIndex * (indicatorWidth + TAB_GAP),
       friction: 8,
       tension: 40,
       useNativeDriver: true,
     }).start();
-  }, [selectedTab, indicatorPosition]);
+  }, [indicatorPosition, indicatorWidth, selectedTabIndex]);
+
+  const handleTabsLayout = (event: LayoutChangeEvent) => {
+    setTabsWidth(event.nativeEvent.layout.width);
+  };
 
   const handleTabPress = (tab: CockpitTab) => {
     if (tab !== selectedTab) {
@@ -107,7 +120,7 @@ export function CockpitTabs({ selectedTab, onTabChange }: CockpitTabsProps) {
 
   return (
     <View style={[styles.container, { borderBottomColor: colors.border }]}>
-      <View style={styles.tabsRow}>
+      <View style={styles.tabsRow} onLayout={handleTabsLayout}>
         {TABS.map((tab) => {
           const isSelected = tab.id === selectedTab;
           const textColor = isSelected ? colors.tint : colors.textSecondary;
@@ -138,15 +151,8 @@ export function CockpitTabs({ selectedTab, onTabChange }: CockpitTabsProps) {
             styles.indicator,
             {
               backgroundColor: colors.tint,
-              width: `${100 / TABS.length}%`,
-              transform: [
-                {
-                  translateX: indicatorPosition.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [0, 100 * (TABS.length - 1)],
-                  }),
-                },
-              ],
+              width: indicatorWidth,
+              transform: [{ translateX: indicatorPosition }],
             },
           ]}
         />

--- a/components/cockpit/FlightMapView.tsx
+++ b/components/cockpit/FlightMapView.tsx
@@ -12,7 +12,7 @@ import { useColorScheme } from '@/hooks/use-color-scheme';
 import type { Airport } from '@/types/airport';
 import type { Position } from '@/utils/flightInterpolation';
 import { generateRouteWaypoints } from '@/utils/flightInterpolation';
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import MapView, { Marker, Polyline, PROVIDER_GOOGLE } from 'react-native-maps';
 
@@ -63,27 +63,35 @@ export function FlightMapView({
   const mapRef = useRef<MapView>(null);
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
+  const [isMapReady, setIsMapReady] = useState(false);
 
-  // Generate route waypoints (100 points for smooth curve)
   const routeWaypoints = useMemo(() => {
     return generateRouteWaypoints(origin, destination, 100);
-  }, [origin.lat, origin.lon, destination.lat, destination.lon]);
+  }, [destination, origin]);
 
-  // Fit map to show full route on mount
-  useEffect(() => {
-    if (mapRef.current) {
-      mapRef.current.fitToCoordinates(
-        [
-          { latitude: origin.lat, longitude: origin.lon },
-          { latitude: destination.lat, longitude: destination.lon },
-        ],
-        {
-          edgePadding: { top: 100, right: 50, bottom: 100, left: 50 },
-          animated: true,
-        }
-      );
+  const routeCoordinates = useMemo(() => {
+    return routeWaypoints.map((waypoint) => ({
+      latitude: waypoint.lat,
+      longitude: waypoint.lon,
+    }));
+  }, [routeWaypoints]);
+
+  const fitRoute = useCallback(() => {
+    if (!mapRef.current || !isMapReady || routeCoordinates.length === 0) {
+      return;
     }
-  }, [origin, destination]);
+
+    setTimeout(() => {
+      mapRef.current?.fitToCoordinates(routeCoordinates, {
+        edgePadding: { top: 120, right: 56, bottom: 120, left: 56 },
+        animated: true,
+      });
+    }, 150);
+  }, [isMapReady, routeCoordinates]);
+
+  useEffect(() => {
+    fitRoute();
+  }, [fitRoute]);
 
   return (
     <View style={styles.container}>
@@ -98,6 +106,7 @@ export function FlightMapView({
         showsScale={true}
         rotateEnabled={true}
         pitchEnabled={false}
+        onMapReady={() => setIsMapReady(true)}
       >
         {/* Route polyline */}
         <Polyline

--- a/components/cockpit/TimerDisplay.tsx
+++ b/components/cockpit/TimerDisplay.tsx
@@ -25,13 +25,17 @@ export interface TimerDisplayProps {
 const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
-    paddingVertical: Spacing.lg,
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.md,
+    paddingBottom: Spacing.lg,
   },
   timerText: {
-    fontSize: 64,
+    fontSize: 56,
     fontWeight: Typography.fontWeight.bold as any,
     letterSpacing: -2,
+    lineHeight: 64,
     fontVariant: ['tabular-nums'] as any,
+    includeFontPadding: false,
   },
   phaseContainer: {
     flexDirection: 'row',
@@ -126,7 +130,12 @@ export function TimerDisplay({ remainingSeconds, phase, progressPercent }: Timer
 
   return (
     <View style={styles.container}>
-      <ThemedText style={[styles.timerText, { color: timerColor }]}>
+      <ThemedText
+        style={[styles.timerText, { color: timerColor }]}
+        adjustsFontSizeToFit
+        minimumFontScale={0.75}
+        numberOfLines={1}
+      >
         {formattedTime}
       </ThemedText>
       

--- a/components/flight/BoardingPass.tsx
+++ b/components/flight/BoardingPass.tsx
@@ -11,8 +11,7 @@ import { useMemo } from 'react';
 import { StyleSheet, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 
 import { ThemedText } from '@/components/themed-text';
-import { BoardingPassDimensions, Colors, Spacing, Typography } from '@/constants/theme';
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { BoardingPassDimensions, Spacing, Typography } from '@/constants/theme';
 import { BoardingPass as BoardingPassType } from '@/types/flight';
 
 const flexOne = { flex: 1 } as const;
@@ -94,33 +93,18 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   stubSection: {
-    paddingTop: Spacing.lg,
-  },
-  qrPlaceholder: {
-    width: 128,
-    height: 128,
-    backgroundColor: '#FFFFFF',
-    borderRadius: 8,
-    alignSelf: 'center',
-    marginBottom: Spacing.md,
-    justifyContent: 'center',
     alignItems: 'center',
-  },
-  qrText: {
-    fontSize: Typography.fontSize.xs,
-    textAlign: 'center',
-    lineHeight: 18,
-    paddingHorizontal: Spacing.sm,
+    gap: Spacing.xs,
+    paddingTop: Spacing.lg,
   },
   serialNumber: {
     fontSize: Typography.fontSize.xs,
     fontFamily: 'monospace',
     textAlign: 'center',
   },
-  qrNote: {
+  stubTitle: {
     fontSize: Typography.fontSize.xs,
     textAlign: 'center',
-    marginTop: Spacing.xs,
   },
   passengerSection: {
     marginBottom: Spacing.lg,
@@ -156,17 +140,13 @@ interface ScaledStyles {
   detailValue: { fontSize: number };
   passengerSection: { marginBottom: number };
   passengerName: { fontSize: number; letterSpacing: number };
-  qrPlaceholder: { width: number; height: number };
-  qrText: { fontSize: number; lineHeight: number };
   serialNumber: { fontSize: number };
-  qrNote: { fontSize: number };
+  stubTitle: { fontSize: number };
   passPadding: { padding: number };
   headerSpacing: { paddingBottom: number; marginBottom: number };
   routeSpacing: { marginBottom: number; paddingVertical: number };
   detailRow: { marginBottom: number };
   stubSection: { left: number; right: number; paddingTop: number };
-  qrPlaceholderSpacing: { marginBottom: number };
-  qrNoteSpacing: { marginTop: number };
 }
 
 interface DetailPairProps {
@@ -333,16 +313,11 @@ function StubSection({
         { position: 'absolute', top: stubTop },
       ]}
     >
-      <View style={[styles.qrPlaceholder, scaledStyles.qrPlaceholder, scaledStyles.qrPlaceholderSpacing]}>
-        <ThemedText style={[styles.qrText, scaledStyles.qrText, { color: '#000000' }]}>
-          BOARDING CODE{'\n'}
-          {bookingReference}
-        </ThemedText>
-      </View>
-      <ThemedText
-        style={[styles.qrNote, scaledStyles.qrNote, scaledStyles.qrNoteSpacing, { color: colors.textSecondary }]}
-      >
-        QR rendering is not wired up yet in this build.
+      <ThemedText style={[styles.stubTitle, scaledStyles.stubTitle, { color: colors.textSecondary }]}>
+        Boarding Reference
+      </ThemedText>
+      <ThemedText style={[styles.detailValue, scaledStyles.detailValue, { color: colors.text }]}>
+        {bookingReference}
       </ThemedText>
       <ThemedText style={[styles.serialNumber, scaledStyles.serialNumber, { color: colors.textSecondary }]}>
         {serialNumber}
@@ -356,8 +331,6 @@ export function BoardingPass({
   interactive = false,
   onTap,
 }: BoardingPassProps) {
-  const colorScheme = useColorScheme();
-  const colors = Colors[colorScheme ?? 'light'];
   const { width: screenWidth } = useWindowDimensions();
   const passColors: PassColors = {
     background: '#1E3A8A',
@@ -390,16 +363,8 @@ export function BoardingPass({
         fontSize: Typography.fontSize.lg * scale,
         letterSpacing: Math.max(1, 2 * scale),
       },
-      qrPlaceholder: {
-        width: 128 * scale,
-        height: 128 * scale,
-      },
-      qrText: {
-        fontSize: Math.max(10, Typography.fontSize.xs * scale),
-        lineHeight: Math.max(14, 18 * scale),
-      },
       serialNumber: { fontSize: Math.max(10, Typography.fontSize.xs * scale) },
-      qrNote: { fontSize: Math.max(10, Typography.fontSize.xs * scale) },
+      stubTitle: { fontSize: Math.max(10, Typography.fontSize.xs * scale) },
       passPadding: { padding: Spacing.lg * scale },
       headerSpacing: { paddingBottom: Spacing.md * scale, marginBottom: Spacing.md * scale },
       routeSpacing: { marginBottom: Spacing.lg * scale, paddingVertical: Spacing.md * scale },
@@ -409,8 +374,6 @@ export function BoardingPass({
         right: Spacing.lg * scale,
         paddingTop: Spacing.lg * scale,
       },
-      qrPlaceholderSpacing: { marginBottom: Spacing.md * scale },
-      qrNoteSpacing: { marginTop: Spacing.xs * scale },
     }),
     [scale]
   );

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,14 +5,14 @@ module.exports = {
   roots: ['<rootDir>'],
   testMatch: ['**/__tests__/utils/**/*.test.ts', '**/__tests__/services/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'node'],
-  testPathIgnorePatterns: ['/node_modules/', '/.expo/'],
+  testPathIgnorePatterns: ['/node_modules/', '/.expo/', '/.worktrees/'],
   collectCoverageFrom: [
     'utils/**/*.ts',
     'services/**/*.ts',
     '!**/*.test.ts',
     '!**/*.spec.ts',
   ],
-  coveragePathIgnorePatterns: ['/node_modules/', '/.expo/'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/.expo/', '/.worktrees/'],
   coverageThreshold: {
     global: {
       branches: 90,

--- a/screens/FlightDestinationScreen.tsx
+++ b/screens/FlightDestinationScreen.tsx
@@ -232,13 +232,20 @@ function DestinationStepHeader({
     <View style={styles.header}>
       <TouchableOpacity
         onPress={onBack}
-        style={[styles.headerButton, { backgroundColor: colors.cardBackground }]}
+        style={[
+          styles.headerButton,
+          {
+            backgroundColor: colors.primary,
+            borderWidth: 1,
+            borderColor: colors.primary,
+          },
+        ]}
         accessibilityLabel="Back to flight setup"
         accessibilityRole="button"
         testID="back-to-flight-setup"
         hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
       >
-        <IconSymbol name="chevron.left" size={20} color={colors.text} />
+        <IconSymbol name="chevron.left" size={20} color="#FFFFFF" />
       </TouchableOpacity>
       <ThemedText style={styles.headerTitle}>Choose Destination</ThemedText>
       <View style={styles.headerButton} />


### PR DESCRIPTION
## Summary
- hide the stray Expo Router headers across the flight flow
- remove the broken boarding-pass QR/code block and simplify the stub area
- improve flight destination and cockpit UI behavior in dark mode and on-device
- ignore local .worktrees in Jest so the default test command stays reliable

## Testing
- npx tsc --noEmit
- npm test -- --runInBand
- npm run lint
